### PR TITLE
support git push origin <branch> format

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -13,6 +13,13 @@ function getRemoteUrl() {
     return run('git', 'config --get remote.origin.url');
 }
 
+function getCurrentBranch() {
+    return run('git', 'rev-parse --abbrev-ref HEAD').then(function (output) {
+        return output.code === 0 ?
+            output.output.substr(0, output.output.length - 1) : null;
+    });
+}
+
 function hasChanges() {
     // Inverted: reject if run promise is resolved (i.e. `git diff-index` returns exit code 0)
     return when.promise(function(resolve, reject) {
@@ -75,7 +82,11 @@ function tag(version, tag, annotation) {
 }
 
 function push() {
-    return run('git', 'push');
+    return getCurrentBranch().then(function(name) {
+        // default to master branch
+        name = name || 'master';
+        return run('git', 'push origin ' + name);
+    })
 }
 
 function pushTags() {


### PR DESCRIPTION
Fix issue with repository when push.defaults not set (or set to nothing)
fix #1

<branch> is the current branch. 
