### PR TITLE
Add option to be able to specify a different path to publish from.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Options:
     "distStageDir": ".stage",
     "distBase": "dist",
     "distFiles": ["**/*"],
-    "publish": false
+    "publish": false,
+    "publishPath": "bin"
 }
 ```
 

--- a/conf/release.json
+++ b/conf/release.json
@@ -13,5 +13,6 @@
     "distStageDir": ".stage",
     "distBase": "dist",
     "distFiles": ["**/*"],
-    "publish": false
+    "publish": false,
+    "publishPath": "."
 }

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -73,7 +73,8 @@ function build(command) {
 }
 
 function npmPublish(path) {
-    return run('npm', 'publish', path || '.');
+	var options = config.getOptions();
+	return run('npm', 'publish', options.publishPath || path || '.');
 }
 
 function copy(files, options, target) {


### PR DESCRIPTION
When it comes to publishing we want to publish the minified version that is built up in a different folder.  So to allow the option to specify a different root to publish from, I added the option for publishPath.
