### PR TITLE
Add custom registry for `npm ping`

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -53,7 +53,9 @@ class npm {
   }
 
   isRegistryUp() {
-    return this.shell.run('npm ping').then(() => true, () => false);
+    const registry = this.getRegistry();
+    const registryArg = registry !== NPM_DEFAULT_REGISTRY ? ` --registry ${registry}` : '';
+    return this.shell.run(`npm ping${registryArg}`).then(() => true, () => false);
   }
 
   isAuthenticated() {

--- a/test/npm.js
+++ b/test/npm.js
@@ -48,14 +48,17 @@ test('should not throw if validation passes', async t => {
 });
 
 test('should throw if npm is down', async t => {
+  const registry = 'https://www.npmjs.com';
   const run = sinon.stub().resolves();
-  run.withArgs('npm ping').rejects();
+  run.withArgs(`npm ping --registry ${registry}`).rejects();
+
   const npmClient = new npm({
     name: 'pkg',
     publish: true,
     shell: {
       run
-    }
+    },
+    publishConfig: { registry }
   });
   await t.throwsAsync(npmClient.validate(), /Unable to reach npm registry/);
 });

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -292,6 +292,7 @@ test.serial('should run tasks without package.json', async t => {
     );
     await tasks({ npm: { name: pkgName } }, stubs);
 
+    t.is(npmStub.firstCall.args[0], `npm ping --registry ${registry}`);
     t.is(npmStub.secondCall.args[0], `npm whoami --registry ${registry}`);
     t.true(log.log.firstCall.args[0].endsWith(`${registry}/package/${pkgName}`));
   });


### PR DESCRIPTION
Firstly thanks for adding support for `publishConfig.registry`.

This PR adds a fix for [#471](https://github.com/release-it/release-it/pull/471).

We have a custom NPM service powered by [verdaccio](https://verdaccio.org/), and the registry is like http://192.168.0.1:1234. 

Currently the validation of `this.shell.run('npm ping')` can not get passed.

Thanks.
