### PR TITLE
Improve docs on auto-changelog usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ A tool like [auto-changelog](https://github.com/CookPete/auto-changelog) is a gr
 {
   "scripts": {
     "changelog": "npx auto-changelog --stdout --commit-limit false -u --template ./changelog.hbs",
-    "beforeStage": "npx auto-changelog"
+    "beforeStage": "npx auto-changelog -p"
   }
 }
 ```

--- a/docs/recipes/auto-changelog.md
+++ b/docs/recipes/auto-changelog.md
@@ -14,7 +14,7 @@ Example configuration in the release-it config:
 
 ```json
 "scripts": {
-  "beforeStage": "npx auto-changelog",
+  "beforeStage": "npx auto-changelog -p",
   "changelog": "npx auto-changelog --stdout --commit-limit false --unreleased --template ./preview.hbs"
 }
 ```


### PR DESCRIPTION
Fixes #480.

The main source of confusion was the fact that the `-p` option was missing in the auto-changelog usage suggestion.

I also added some explanations to the script hooks which would have helped me, so probably will help others.

By the way, what is the difference between the `afterBump` and `beforeStage` hooks? That is still not so clear to me. Thanks.