### PR TITLE
Add note in readme about JS config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Notes:
 - Only the settings to override need to be in `.release-it.json` (or `package.json`). Everything else will fall back to
   the [default configuration](conf/release-it.json).
 - You can use `--config` if you want to use another path for `.release-it.json`.
+- You can also use a regular JavaScript file, for example `.release-it.js`, as long as you point to it using `--config`. This can be useful if your configuration depends on something else, so you have all JavaScript power to use instead of a static JSON. Make sure you export the config with `module.exports`.
 
 Any option can also be set on the command-line, and will have highest priority. Example:
 


### PR DESCRIPTION
Using `.release-it.js` instead of `.release-it.json` was something that helped me immensely, I think this possibility deserves to be documented directly.