### PR TITLE
Add note to readme about bumping package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,16 @@ release commit).
 }
 ```
 
+## Bumping `package-lock.json`
+
+By default, `release-it` does not care about `package-lock.json`. If you want its `version` field to be bumped as well, you should use the `pkgFiles` setting, as follows:
+
+```json
+{ 
+  "pkgFiles": ["package.json", "package-lock.json"]
+}
+```
+
 ## Publish to npm
 
 By default, `npm.publish` is `true` and publishing is delegated to `npm publish`.


### PR DESCRIPTION
Wondering about bumping the version on `package-lock.json`, I found #147 which was very helpful. I think this deserves to be directly documented in the readme.
