### PR TITLE
Allow to skip ping and whoiam

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -53,12 +53,18 @@ class npm {
   }
 
   isRegistryUp() {
+    if (this.options.skipPing) {
+      return true;
+    }
     const registry = this.getRegistry();
     const registryArg = registry !== NPM_DEFAULT_REGISTRY ? ` --registry ${registry}` : '';
     return this.shell.run(`npm ping${registryArg}`).then(() => true, () => false);
   }
 
   isAuthenticated() {
+    if (this.options.skipWhoiam) {
+      return true;
+    }
     const registry = this.getRegistry();
     const registryArg = registry !== NPM_DEFAULT_REGISTRY ? ` --registry ${registry}` : '';
     return this.shell.run(`npm whoami${registryArg}`).then(() => true, () => false);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -36,7 +36,12 @@ const runTasks = async (opts, injected = {}) => {
     const changelogs = new Changelog({ shell });
     const ghClient = new GitHub(options.github, options.git, { isDryRun }, { log, changelogs });
     const glClient = new GitLab(options.gitlab, options.git, { isDryRun }, { log, changelogs });
-    const npmClient = new npm(options.npm, { isPreRelease: options.preRelease, isDryRun }, { shell, log });
+    const npmClient = new npm(
+      options.npm,
+      { isPreRelease: options.preRelease, isDryRun },
+      { shell, log },
+      { skipPing: options.skipPing, skipWhoiam: options.skipWhoiam }
+    );
     const v = new Version({ preReleaseId: options.preReleaseId, log });
 
     await Promise.all([gitClient.init(), ghClient.validate(), glClient.validate(), npmClient.validate()]);

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -296,4 +296,50 @@ test.serial('should run tasks without package.json', async t => {
     t.is(npmStub.secondCall.args[0], `npm whoami --registry ${registry}`);
     t.true(log.log.firstCall.args[0].endsWith(`${registry}/package/${pkgName}`));
   });
+
+  test.serial('should skip ping', async t => {
+    const { target } = t.context;
+    const pkgName = path.basename(target);
+    const registry = 'https://my-registry.com';
+
+    gitAdd(
+      JSON.stringify({
+        name: pkgName,
+        version: '1.2.3',
+        publishConfig: { registry },
+        'release-it': {
+          skipPing: true
+        }
+      }),
+      'package.json',
+      'Add package.json'
+    );
+    await tasks({ npm: { name: pkgName } }, stubs);
+
+    t.is(npmStub.firstCall.args[0], `npm whoami --registry ${registry}`);
+    t.true(log.log.firstCall.args[0].endsWith(`${registry}/package/${pkgName}`));
+  });
+
+  test.serial('should skip whoiam', async t => {
+    const { target } = t.context;
+    const pkgName = path.basename(target);
+    const registry = 'https://my-registry.com';
+
+    gitAdd(
+      JSON.stringify({
+        name: pkgName,
+        version: '1.2.3',
+        publishConfig: { registry },
+        'release-it': {
+          skipWhoiam: true
+        }
+      }),
+      'package.json',
+      'Add package.json'
+    );
+    await tasks({ npm: { name: pkgName } }, stubs);
+
+    t.is(npmStub.firstCall.args[0], `npm ping --registry ${registry}`);
+    t.true(log.log.firstCall.args[0].endsWith(`${registry}/package/${pkgName}`));
+  });
 }


### PR DESCRIPTION
This is useful when using custom npm registries that not support the
endpoints.

[Nexus](https://help.sonatype.com/repomanager2/node-packaged-modules-and-npm-registries) npm registry don't have the [ping](https://issues.sonatype.org/browse/NEXUS-13434) or [whoiam](https://issues.sonatype.org/browse/NEXUS-13433) endpoint implemented. 
This allows to users using such registry to skip those checks in order to publish.