### PR TITLE
Fix 'push to remote name not origin test'

### DIFF
--- a/test/git.js
+++ b/test/git.js
@@ -184,7 +184,7 @@ test.serial('should push to remote name (not "origin")', async t => {
     gitAdd('line', 'file', 'Add file');
     await gitClient.push();
     t.is(spy.lastCall.args[0], 'git push --follow-tags  -u upstream foo');
-    t.is(await spy.lastCall.returnValue, "Branch 'foo' set up to track remote branch 'foo' from 'upstream'.");
+    t.is((await spy.lastCall.returnValue).replace(/'/g, ''), "Branch foo set up to track remote branch foo from upstream.");
   }
   spy.restore();
 });


### PR DESCRIPTION
This test was failing only because the branch and remote names were single quoted. I don't know if they fail for everyone; may not be a useful PR if this just breaks for other people.