### PR TITLE
Support package-lock

### DIFF
--- a/conf/release-it.json
+++ b/conf/release-it.json
@@ -1,6 +1,6 @@
 {
   "preReleaseId": null,
-  "pkgFiles": ["package.json"],
+  "pkgFiles": ["package.json", "package-lock.json"],
   "use": "git.tag",
   "scripts": {
     "beforeStart": null,


### PR DESCRIPTION
It's possible to include package-lock.json in .release-it.json in pkgFiles, but since release-it depends on node engine >= 8 and package-lock.json has been default since 5 (and should be checked into source control), I think it be expected behavior for a lot of people. Possibly people don't realize that their package-lock.json is not getting updated, so this could be a somewhat hidden issue for a lot of people.

Take with a grain of salt. I'm by no means an expert at node or npm. Let me know how I could handle this better for you.