### PR TITLE
Add initial draft step to GitHub release

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -163,9 +163,10 @@ class GitHub extends Release {
     return `https://${host}/${repository}/releases/tag/${tag}`;
   }
 
-  maybePublishRelease() {
-    const { draft } = this.options;
+  maybePublishRelease({ version } = {}) {
+    const { draft, tagName } = this.options;
     const { owner, project: repo } = this.repo;
+    const tag_name = format(tagName, { version });
 
     if (draft) {
       // The user actually wanted a draft so we don't publish.
@@ -178,12 +179,14 @@ class GitHub extends Release {
           owner,
           repo,
           draft,
-          release_id: this.releaseId
+          release_id: this.releaseId,
+          tag_name
         };
         debug(options);
         const response = await this.client.repos.updateRelease(options);
         debug(response.data);
         this.log.verbose(`octokit releases#publishRelease: done (${response.headers.location})`);
+        this.releaseUrl = response.data.html_url;
         return response.data;
       } catch (err) {
         return this.handleError(err, bail);

--- a/lib/github.js
+++ b/lib/github.js
@@ -67,7 +67,7 @@ class GitHub extends Release {
     return ghClient;
   }
 
-  async release({ version, isPreRelease, changelog } = {}) {
+  async draftRelease({ version, isPreRelease, changelog } = {}) {
     const { tagName, releaseName, releaseNotes, isDryRun } = this.options;
     const tag_name = format(tagName, { version });
     const name = format(releaseName, { version });

--- a/lib/github.js
+++ b/lib/github.js
@@ -81,7 +81,6 @@ class GitHub extends Release {
       return noop;
     }
 
-    const { draft } = this.options;
     const { owner, project: repo } = this.repo;
 
     return this.retry(async bail => {
@@ -93,14 +92,15 @@ class GitHub extends Release {
           name,
           body,
           prerelease: isPreRelease,
-          draft
+          draft: true
         };
         debug(options);
         const response = await this.client.repos.createRelease(options);
         debug(response.data);
-        const { html_url, upload_url } = response.data;
+        const { html_url, upload_url, id } = response.data;
         this.log.verbose(`octokit releases#createRelease: done (${response.headers.location})`);
         this.releaseUrl = html_url;
+        this.releaseId = id;
         this.uploadUrl = upload_url;
         this.isReleased = true;
         return response.data;
@@ -161,6 +161,36 @@ class GitHub extends Release {
     const tag = format(this.options.tagName, { version });
     const { host, repository } = this.repo;
     return `https://${host}/${repository}/releases/tag/${tag}`;
+  }
+
+  maybePublishRelease() {
+    const { draft } = this.options;
+    const { owner, project: repo } = this.repo;
+
+    if (draft) {
+      // The user actually wanted a draft so we don't publish.
+      return;
+    }
+
+    return this.retry(async bail => {
+      try {
+        const options = {
+          owner,
+          repo,
+          draft,
+          release_id: this.releaseId
+        };
+        debug(options);
+        const response = await this.client.repos.updateRelease(options);
+        debug(response.data);
+        const { html_url } = response.data;
+        this.log.verbose(`octokit releases#publishRelease: done (${response.headers.location})`);
+        this.releaseUrl = html_url;
+        return response.data;
+      } catch (err) {
+        return this.handleError(err, bail);
+      }
+    });
   }
 }
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -183,9 +183,7 @@ class GitHub extends Release {
         debug(options);
         const response = await this.client.repos.updateRelease(options);
         debug(response.data);
-        const { html_url } = response.data;
         this.log.verbose(`octokit releases#publishRelease: done (${response.headers.location})`);
-        this.releaseUrl = html_url;
         return response.data;
       } catch (err) {
         return this.handleError(err, bail);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -128,18 +128,19 @@ const runTasks = async (opts, injected = {}) => {
 
       // GitHub
       github.release && github.releaseNotes && logPreview(log, 'release notes', await ghClient.getNotes());
-      const ghRelease = () => ghClient.release({ version, isPreRelease, changelog });
+      const ghDraftRelease = () => ghClient.draftRelease({ version, isPreRelease, changelog });
       const ghUploadAssets = () => ghClient.uploadAssets();
-      const ghPublishRelease = () => ghClient.maybePublishRelease();
+      const ghMaybePublishRelease = () => ghClient.maybePublishRelease();
       if (isInteractive) {
         const release = () =>
-          ghRelease()
+          ghDraftRelease()
             .then(() => ghUploadAssets())
-            .then(() => ghPublishRelease());
+            .then(() => ghMaybePublishRelease());
         await step({ enabled: github.release, task: release, label: 'GitHub release', prompt: 'ghRelease' });
       } else {
-        await step({ enabled: github.release, task: ghRelease, label: 'GitHub release' });
+        await step({ enabled: github.release, task: ghDraftRelease, label: 'GitHub draft release' });
         await step({ enabled: github.assets, task: ghUploadAssets, label: 'GitHub upload assets' });
+        await step({ enabled: github.release, task: ghMaybePublishRelease, label: 'GitHub publish release' });
       }
 
       // GitLab

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -130,9 +130,12 @@ const runTasks = async (opts, injected = {}) => {
       github.release && github.releaseNotes && logPreview(log, 'release notes', await ghClient.getNotes());
       const ghRelease = () => ghClient.release({ version, isPreRelease, changelog });
       const ghUploadAssets = () => ghClient.uploadAssets();
-			const ghPublishRelease = () => ghClient.maybePublishRelease();
+      const ghPublishRelease = () => ghClient.maybePublishRelease();
       if (isInteractive) {
-        const release = () => ghRelease().then(() => ghUploadAssets()).then(() => ghPublishRelease());
+        const release = () =>
+          ghRelease()
+            .then(() => ghUploadAssets())
+            .then(() => ghPublishRelease());
         await step({ enabled: github.release, task: release, label: 'GitHub release', prompt: 'ghRelease' });
       } else {
         await step({ enabled: github.release, task: ghRelease, label: 'GitHub release' });

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -130,8 +130,9 @@ const runTasks = async (opts, injected = {}) => {
       github.release && github.releaseNotes && logPreview(log, 'release notes', await ghClient.getNotes());
       const ghRelease = () => ghClient.release({ version, isPreRelease, changelog });
       const ghUploadAssets = () => ghClient.uploadAssets();
+			const ghPublishRelease = () => ghClient.maybePublishRelease();
       if (isInteractive) {
-        const release = () => ghRelease().then(() => ghUploadAssets());
+        const release = () => ghRelease().then(() => ghUploadAssets()).then(() => ghPublishRelease());
         await step({ enabled: github.release, task: release, label: 'GitHub release', prompt: 'ghRelease' });
       } else {
         await step({ enabled: github.release, task: ghRelease, label: 'GitHub release' });

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -130,7 +130,7 @@ const runTasks = async (opts, injected = {}) => {
       github.release && github.releaseNotes && logPreview(log, 'release notes', await ghClient.getNotes());
       const ghDraftRelease = () => ghClient.draftRelease({ version, isPreRelease, changelog });
       const ghUploadAssets = () => ghClient.uploadAssets();
-      const ghMaybePublishRelease = () => ghClient.maybePublishRelease();
+      const ghMaybePublishRelease = () => ghClient.maybePublishRelease({ version });
       if (isInteractive) {
         const release = () =>
           ghDraftRelease()

--- a/test/github.js
+++ b/test/github.js
@@ -61,23 +61,19 @@ test('should release and upload assets', async t => {
   t.is(releaseResult.tag_name, 'v' + version);
   t.is(releaseResult.name, 'Release ' + version);
 
-  const github2 = new GitHub({
-    release: true,
-    releaseNotes: 'echo Custom notes',
-    remoteUrl,
-    tagName,
-    assets: path.resolve('test/resources', asset)
-  });
-
-  const publishedResult = await github2.maybePublishRelease({
-    draft: false
-  });
-
   t.is(github.isReleased, true);
   t.is(github.getReleaseUrl(), 'https://github.com/webpro/release-it-test/releases/tag/v2.0.1');
 
-  t.is(publishedResult.tag_name, 'v' + version);
-  t.is(publishedResult.name, 'Release ' + version);
+  t.is(releaseResult.tag_name, 'v' + version);
+  t.is(releaseResult.name, 'Release ' + version);
+  t.is(releaseResult.draft, true);
+
+  const publishedResult = await github.maybePublishRelease({
+    draft: false
+  });
+
+  t.is(publishedResult.draft, false);
+
   t.is(githubRequestStub.callCount, 2);
   t.is(githubRequestStub.firstCall.lastArg.owner, 'webpro');
   t.is(githubRequestStub.firstCall.lastArg.repo, 'release-it-test');
@@ -87,7 +83,7 @@ test('should release and upload assets', async t => {
 
   const [uploadResult] = await github.uploadAssets();
 
-  t.is(GitHubApiStub.callCount, 2);
+  t.is(GitHubApiStub.callCount, 1);
   t.deepEqual(GitHubApiStub.firstCall.args[0], {
     baseUrl: 'https://api.github.com',
     auth: `token ${github.token}`,

--- a/test/github.js
+++ b/test/github.js
@@ -58,6 +58,10 @@ test('should release and upload assets', async t => {
     version
   });
 
+  const publishedResult = await github.maybePublishRelease({
+    draft: false
+  });
+
   t.is(github.isReleased, true);
   t.is(github.getReleaseUrl(), 'https://github.com/webpro/release-it-test/releases/tag/v2.0.1');
 

--- a/test/github.js
+++ b/test/github.js
@@ -68,6 +68,8 @@ test('should release and upload assets', async t => {
   t.is(releaseResult.name, 'Release ' + version);
   t.is(releaseResult.draft, true);
 
+  t.is(githubRequestStub.callCount, 1);
+
   const publishedResult = await github.maybePublishRelease({
     draft: false
   });

--- a/test/github.js
+++ b/test/github.js
@@ -54,7 +54,7 @@ test('should release and upload assets', async t => {
   t.is(attempt, undefined);
   t.is(githubRequestStub.callCount, 0);
 
-  const releaseResult = await github.release({
+  const releaseResult = await github.draftRelease({
     version
   });
 
@@ -106,7 +106,7 @@ test('should release to enterprise host', async t => {
     remoteUrl: 'https://github.my-GHE-enabled-company.com/user/repo'
   });
 
-  await github.release({
+  await github.draftRelease({
     version: '1',
     changelog: 'My default changelog'
   });
@@ -125,7 +125,7 @@ test('should release to alternative host and proxy', async t => {
     proxy: 'http://proxy:8080'
   });
 
-  await github.release();
+  await github.draftRelease();
 
   t.is(GitHubApiStub.callCount, 1);
   t.is(GitHubApiStub.firstCall.args[0].baseUrl, 'https://my-custom-host.org/api/v3');
@@ -137,7 +137,7 @@ test('should handle octokit client error (without retries)', async t => {
   const stub = sinon.stub(gitHubApi.repos, 'createRelease');
   stub.throws(new HttpError('Not found', 404, null, { url: '', headers: {} }));
   const github = new GitHub({ release: true, remoteUrl: '' });
-  await t.throwsAsync(github.release(), { instanceOf: GitHubClientError, message: '404 (Not found)' });
+  await t.throwsAsync(github.draftRelease(), { instanceOf: GitHubClientError, message: '404 (Not found)' });
   t.is(stub.callCount, 1);
   stub.restore();
 });
@@ -147,7 +147,7 @@ test('should handle octokit client error (with retries)', async t => {
   const stub = sinon.stub(gitHubApi.repos, 'createRelease');
   stub.throws(new HttpError('Request failed', 500, null, { url: '', headers: {} }));
   const github = new GitHub({ release: true, remoteUrl: '', retryMinTimeout: 0 });
-  await t.throwsAsync(github.release(), { instanceOf: GitHubClientError, message: '500 (Request failed)' });
+  await t.throwsAsync(github.draftRelease(), { instanceOf: GitHubClientError, message: '500 (Request failed)' });
   t.is(stub.callCount, 3);
   stub.restore();
 });
@@ -166,7 +166,7 @@ test('should not call octokit client in dry run', async t => {
 
   const spy = sinon.spy(github, 'uploadAsset');
 
-  await github.release({
+  await github.draftRelease({
     version: '1'
   });
 

--- a/test/stub/github.request.js
+++ b/test/stub/github.request.js
@@ -3,7 +3,7 @@ const releases = {};
 
 module.exports = (request, options) => {
   const { url } = options;
-  if (url === '/repos/:owner/:repo/releases') {
+  if (url === '/repos/:owner/:repo/releases' || url === '/repos/:owner/:repo/releases/:release_id') {
     const id = uuid();
     const { tag_name, name, body, prerelease, draft, owner, repo } = options;
     releases[id] = {

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -165,7 +165,7 @@ test.serial('should run tasks without package.json', async t => {
     t.is(githubReleaseArg.name, 'Release 1.0.1');
     t.true(githubReleaseArg.body.startsWith('* More file'));
     t.is(githubReleaseArg.prerelease, false);
-    t.is(githubReleaseArg.draft, false);
+    t.is(githubReleaseArg.draft, true);
 
     t.is(npmStub.callCount, 4);
     t.is(npmStub.firstCall.args[0], 'npm ping');
@@ -207,7 +207,7 @@ test.serial('should run tasks without package.json', async t => {
       stubs
     );
 
-    t.is(githubRequestStub.callCount, 2);
+    t.is(githubRequestStub.callCount, 3);
 
     const githubReleaseArg = githubRequestStub.firstCall.lastArg;
     t.is(githubReleaseArg.url, '/repos/:owner/:repo/releases');
@@ -247,7 +247,7 @@ test.serial('should run tasks without package.json', async t => {
     gitAdd(`{"name":"${pkgName}","version":"1.0.0"}`, 'package.json', 'Add package.json');
     sh.exec('git tag v1.0.0');
     await tasks({ increment: 'major', preRelease: true, npm: { name: pkgName, tag: 'next' } }, stubs);
-    t.is(npmStub.callCount, 4);
+    t.is(npmStub.callCount, 12);
     t.is(npmStub.lastCall.args[0], 'npm publish . --tag next');
     const { stdout } = sh.exec('git describe --tags --abbrev=0');
     t.is(stdout.trim(), '2.0.0-0');

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -55,7 +55,7 @@ test.serial.beforeEach(t => {
   const bare = path.resolve(cwd, 'tmp', uuid());
   const target = path.resolve(cwd, 'tmp', uuid());
   sh.pushd('-q', `${cwd}/tmp`);
-  sh.exec(`git init --mirror ${bare}`);
+  sh.exec(`git init --bare ${bare}`);
   sh.exec(`git clone ${bare} ${target}`);
   sh.pushd('-q', target);
   gitAdd('line', 'file', 'Add file');

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -207,7 +207,7 @@ test.serial('should run tasks without package.json', async t => {
       stubs
     );
 
-    t.is(githubRequestStub.callCount, 3);
+    t.is(githubRequestStub.callCount, 2);
 
     const githubReleaseArg = githubRequestStub.firstCall.lastArg;
     t.is(githubReleaseArg.url, '/repos/:owner/:repo/releases');
@@ -247,7 +247,7 @@ test.serial('should run tasks without package.json', async t => {
     gitAdd(`{"name":"${pkgName}","version":"1.0.0"}`, 'package.json', 'Add package.json');
     sh.exec('git tag v1.0.0');
     await tasks({ increment: 'major', preRelease: true, npm: { name: pkgName, tag: 'next' } }, stubs);
-    t.is(npmStub.callCount, 12);
+    t.is(npmStub.callCount, 8);
     t.is(npmStub.lastCall.args[0], 'npm publish . --tag next');
     const { stdout } = sh.exec('git describe --tags --abbrev=0');
     t.is(stdout.trim(), '2.0.0-0');

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -55,7 +55,7 @@ test.serial.beforeEach(t => {
   const bare = path.resolve(cwd, 'tmp', uuid());
   const target = path.resolve(cwd, 'tmp', uuid());
   sh.pushd('-q', `${cwd}/tmp`);
-  sh.exec(`git init --bare ${bare}`);
+  sh.exec(`git init --mirror ${bare}`);
   sh.exec(`git clone ${bare} ${target}`);
   sh.pushd('-q', target);
   gitAdd('line', 'file', 'Add file');
@@ -217,7 +217,7 @@ test.serial('should run tasks without package.json', async t => {
     t.is(githubReleaseArg.name, 'Release 1.1.0-alpha.0');
     t.regex(githubReleaseArg.body, RegExp(`Notes for ${pkgName} \\(v1.1.0-alpha.0\\): \\* More file`));
     t.is(githubReleaseArg.prerelease, true);
-    t.is(githubReleaseArg.draft, false);
+    t.is(githubReleaseArg.draft, true);
 
     const githubAssetsArg = githubRequestStub.secondCall.lastArg;
     const { id } = githubRequestStub.firstCall.returnValue.data;

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -157,7 +157,7 @@ test.serial('should run tasks without package.json', async t => {
     gitAdd('line', 'file', 'More file');
     await tasks({ github: { release: true }, npm: { name: pkgName, publish: true } }, stubs);
     const githubReleaseArg = githubRequestStub.firstCall.lastArg;
-    t.is(githubRequestStub.callCount, 1);
+    t.is(githubRequestStub.callCount, 2);
     t.is(githubReleaseArg.url, '/repos/:owner/:repo/releases');
     t.is(githubReleaseArg.owner, owner);
     t.is(githubReleaseArg.repo, repoName);
@@ -207,9 +207,9 @@ test.serial('should run tasks without package.json', async t => {
       stubs
     );
 
-    t.is(githubRequestStub.callCount, 2);
+    t.is(githubRequestStub.callCount, 5);
 
-    const githubReleaseArg = githubRequestStub.firstCall.lastArg;
+    const githubReleaseArg = githubRequestStub.thirdCall.lastArg;
     t.is(githubReleaseArg.url, '/repos/:owner/:repo/releases');
     t.is(githubReleaseArg.owner, owner);
     t.is(githubReleaseArg.repo, repoName);
@@ -247,11 +247,11 @@ test.serial('should run tasks without package.json', async t => {
     gitAdd(`{"name":"${pkgName}","version":"1.0.0"}`, 'package.json', 'Add package.json');
     sh.exec('git tag v1.0.0');
     await tasks({ increment: 'major', preRelease: true, npm: { name: pkgName, tag: 'next' } }, stubs);
-    t.is(npmStub.callCount, 4);
+    t.is(npmStub.callCount, 12);
     t.is(npmStub.lastCall.args[0], 'npm publish . --tag next');
     const { stdout } = sh.exec('git describe --tags --abbrev=0');
     t.is(stdout.trim(), '2.0.0-0');
-    t.true(log.obtrusive.firstCall.args[0].endsWith(`release ${pkgName} (1.0.0...2.0.0-0)`));
+    t.true(log.obtrusive.thirdCall.args[0].endsWith(`release ${pkgName} (1.0.0...2.0.0-0)`));
     t.true(log.log.firstCall.args[0].endsWith(`https://www.npmjs.com/package/${pkgName}`));
     t.regex(log.log.lastCall.args[0], /Done \(in [0-9]+s\.\)/);
   });

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -247,7 +247,7 @@ test.serial('should run tasks without package.json', async t => {
     gitAdd(`{"name":"${pkgName}","version":"1.0.0"}`, 'package.json', 'Add package.json');
     sh.exec('git tag v1.0.0');
     await tasks({ increment: 'major', preRelease: true, npm: { name: pkgName, tag: 'next' } }, stubs);
-    t.is(npmStub.callCount, 8);
+    t.is(npmStub.callCount, 4);
     t.is(npmStub.lastCall.args[0], 'npm publish . --tag next');
     const { stdout } = sh.exec('git describe --tags --abbrev=0');
     t.is(stdout.trim(), '2.0.0-0');


### PR DESCRIPTION
This PR moves the actual publishing of the GitHub release to after the release assets have been uploaded.

This is important because Github Action triggers a release on publish, so it is possible that release assets might not be visible to the action, as they are yet to be uploaded.

see #https://github.com/release-it/release-it/issues/495