### PR TITLE
npm.ping option to disable npm ping in case your repo doesn't support it

### DIFF
--- a/conf/release-it.json
+++ b/conf/release-it.json
@@ -23,6 +23,7 @@
     "pushRepo": "origin"
   },
   "npm": {
+    "ping": true,
     "publish": true,
     "publishPath": ".",
     "access": null,

--- a/lib/plugin/npm/npm.js
+++ b/lib/plugin/npm/npm.js
@@ -85,6 +85,7 @@ class npm extends Plugin {
   }
 
   isRegistryUp() {
+    if (this.options.ping === false) return true;
     const registry = this.getRegistry();
     const registryArg = registry !== NPM_DEFAULT_REGISTRY ? ` --registry ${registry}` : '';
     return this.exec(`npm ping${registryArg}`).then(


### PR DESCRIPTION
e.g., https://issues.sonatype.org/browse/NEXUS-13434

I prefer this option rather than extending the check for which errors to ignore. But let me know if you would like me to extend the regex instead?