### PR TITLE
Fix timeout issue with 3rd party npm registries.

### DIFF
--- a/lib/plugin/npm/npm.js
+++ b/lib/plugin/npm/npm.js
@@ -118,10 +118,12 @@ class npm extends Plugin {
   }
 
   async getLatestRegistryVersion() {
+    const registry = this.getRegistry();
+    const registryArg = registry !== NPM_DEFAULT_REGISTRY ? ` --registry ${registry}` : '';
     const name = this.getName();
     const latestVersion = this.getLatestVersion();
     const tag = await this.resolveTag(latestVersion);
-    return this.exec(`npm show ${name}@${tag} version`, { options }).catch(() => null);
+    return this.exec(`npm show ${name}@${tag} version${registryArg}`, { options }).catch(() => null);
   }
 
   getRegistryPreReleaseTags() {


### PR DESCRIPTION
I ran into a Timeout issue when using a 3rd Party NPM registries (JFROG Artifactory).

I noticed that the additional argument `--registry` is missing for this check function, so added it in the same fashion as it was made for e.g.`isAuthenticated()`