### PR TITLE
Fix #557 use just HEAD for counting if no tag yet

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -74,7 +74,11 @@ class Git extends GitBase {
 
   async getCommitsSinceLatestTag() {
     const latestTagName = await this.getLatestTagName();
-    return this.exec(`git rev-list ${latestTagName}..HEAD --count`, { options }).then(Number);
+    if (latestTagName === null) {
+      return this.exec(`git rev-list HEAD --count`, { options }).then(Number);
+    } else {
+      return this.exec(`git rev-list ${latestTagName}..HEAD --count`, { options }).then(Number);
+    }
   }
 
   stage(file) {


### PR DESCRIPTION
Just count commits from the first one to HEAD.

May require additional unit tests