### PR TITLE
Catch block on templates to assist in debugging

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -5,11 +5,16 @@ const gitUrlParse = require('git-url-parse');
 const semver = require('semver');
 const { TimeoutError } = require('./errors');
 
-const format = (template = '', context = {}) => {
-  template = template.startsWith('git log')
-    ? template.replace('[REV_RANGE]', '${latestTag}...HEAD')
-    : template.replace(/%s/g, '${version}');
-  return _.template(template)(context);
+const format = (template = "", context = {}) => {
+  try {
+    template = template.startsWith("git log")
+      ? template.replace("[REV_RANGE]", "${latestTag}...HEAD")
+      : template.replace(/%s/g, "${version}");
+    return _.template(template)(context);
+  } catch (e) {
+    console.error("Could not render template '" + template + "'", e);
+    throw e;
+  }
 };
 
 const truncateLines = (input, maxLines = 10, surplusText = null) => {


### PR DESCRIPTION
I spent way too long tracking down an error in a template I had written pre-v10 that broke with an error message that didn't point to my bad template in my config.