### PR TITLE
make hooks example precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ All commands can use configuration variables (like template strings). An array o
 will run one after another. Some examples:
 
 ```json
+// .release-it.json
 {
+  "git": {},
   "hooks": {
     "before:init": ["npm run lint", "npm test"],
     "after:my-plugin:bump": "./bin/my-script.sh",


### PR DESCRIPTION
https://github.com/antvis/gatsby-theme-antv/commit/471b6bbd4a817fa1d03dbdab41b05a80771406ff

A litter misunderstanding of where to place `hooks` fields in `package.json`, especially when `hooks` is popular for precommit or husky.