### PR TITLE
Add auto-changelog template file to be used directly from the repository

### DIFF
--- a/docs/recipes/auto-changelog.md
+++ b/docs/recipes/auto-changelog.md
@@ -45,3 +45,17 @@ unreleased tag:
   {{/if}}
 {{/each}}
 ```
+
+You can also use the template above [changelog-compact-template.hbs](./changelog-compact-template.hbs)
+directly from the URL:
+
+```json
+{
+  "hooks": {
+    "before:release": "npx auto-changelog -p"
+  },
+  "git": {
+    "changelog": "npx auto-changelog --stdout --commit-limit false --unreleased --template https://raw.githubusercontent.com/release-it/release-it/master/docs/recipes/changelog-compact-template.hbs"
+  }
+}
+```

--- a/docs/recipes/changelog-compact-template.hbs
+++ b/docs/recipes/changelog-compact-template.hbs
@@ -1,0 +1,13 @@
+{{#each releases}}
+  {{#if @first}}
+    {{#each merges}}
+      - {{{message}}}{{#if href}} [`#{{id}}`]({{href}}){{/if}}
+    {{/each}}
+    {{#each fixes}}
+      - {{{commit.subject}}}{{#each fixes}}{{#if href}} [`#{{id}}`]({{href}}){{/if}}{{/each}}
+    {{/each}}
+    {{#each commits}}
+      - {{#if breaking}}**Breaking change:** {{/if}}{{{subject}}}{{#if href}} [`{{shorthash}}`]({{href}}){{/if}}
+    {{/each}}
+  {{/if}}
+{{/each}}


### PR DESCRIPTION
Storing the auto-changelog template as a separate file may help other to use it easily form this repository:

```
auto-changelog --stdout --commit-limit false --unreleased --template https://raw.githubusercontent.com/release-it/release-it/master/docs/recipes/changelog-compact-template.hbs
```

This is handy because some people do not want to maintain it's own auto-changelog template and are happy with the default one.