### PR TITLE
feat(gitlab): query inherited members from projekt

### DIFF
--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -65,7 +65,7 @@ class GitLab extends Release {
 
   async isCollaborator() {
     if (this.global.isDryRun) return true;
-    const endpoint = `/projects/${this.id}/members`;
+    const endpoint = `/projects/${this.id}/members/all`;
     const { username } = this.getContext('gitlab');
     try {
       const body = await this.request(endpoint, { method: 'GET' });

--- a/test/stub/gitlab.js
+++ b/test/stub/gitlab.js
@@ -7,7 +7,7 @@ module.exports.interceptUser = ({ host = 'https://gitlab.com', owner = 'user' } 
 
 module.exports.interceptMembers = ({ host = 'https://gitlab.com', owner = 'user', project = 'repo', group } = {}) =>
   nock(host)
-    .get(`/api/v4/projects/${group ? `${group}%2F` : ''}${owner}%2F${project}/members`)
+    .get(`/api/v4/projects/${group ? `${group}%2F` : ''}${owner}%2F${project}/members/all`)
     .reply(200, [{ username: owner, access_level: 30 }]);
 
 module.exports.interceptPublish = ({ host = 'https://gitlab.com', owner = 'user', project = 'repo', body } = {}) =>


### PR DESCRIPTION
Hi,

on our GitLab instance we are managing our users on group level. I noticed that using your query only direct members of the project are returned which results in an error for my current user when releasing a project.
Luckily the GitLab API doc says that we can query inherited members as well, see https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members.

I don't see any disadvantages querying the inherited members as well, whats your opinion on this?

Best regards,

Benedikt