### PR TITLE
Don't include repo on push if branch has upstream

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -170,8 +170,13 @@ class Git extends GitBase {
     } else if (!(await this.hasUpstreamBranch())) {
       // Start tracking upstream branch (`pushRepo` is a name if set)
       upstream = `--set-upstream ${pushRepo || upstream} ${await this.getBranchName()}`;
-    } else if (pushRepo && !invalidPushRepoRe.test(pushRepo)) {
-      upstream = pushRepo;
+    } else {
+      if (!pushRepo || pushRepo === 'origin') {
+        // Push to tracking upstream branch
+        upstream = '';
+      } else if (!invalidPushRepoRe.test(pushRepo)) {
+        upstream = pushRepo;
+      }
     }
     return this.exec(`git push ${args || ''} ${upstream}`);
   }

--- a/test/git.js
+++ b/test/git.js
@@ -165,7 +165,22 @@ test.serial('should push to origin', async t => {
   const gitClient = factory(Git);
   const spy = sinon.spy(gitClient.shell, 'exec');
   await gitClient.push();
-  t.is(spy.lastCall.args[0], 'git push  origin');
+  t.is(spy.lastCall.args[0], 'git push  ');
+  const actual = sh.exec('git ls-tree -r HEAD --name-only', { cwd: bare });
+  t.is(actual.trim(), 'file');
+  spy.restore();
+});
+
+test.serial('should push to tracked upstream branch', async t => {
+  const bare = mkTmpDir();
+  sh.exec(`git init --bare ${bare}`);
+  sh.exec(`git clone ${bare} .`);
+  sh.exec(`git remote rename origin upstream`);
+  gitAdd('line', 'file', 'Add file');
+  const gitClient = factory(Git);
+  const spy = sinon.spy(gitClient.shell, 'exec');
+  await gitClient.push();
+  t.is(spy.lastCall.args[0], 'git push  ');
   const actual = sh.exec('git ls-tree -r HEAD --name-only', { cwd: bare });
   t.is(actual.trim(), 'file');
   spy.restore();


### PR DESCRIPTION
When the branch is tracking upstream branch there should
be no need to explicitly state the origin name. Especially as
that might not be the one that matches tracking information.

Resolves #608