### PR TITLE
Don't include repo on push if branch has upstream (for v13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See the GitHub Releases page for detailed changelogs:
 
 - Dropped support for Node v8
 - Deprecated `scripts` are removed (in favor of [hooks](https://github.com/release-it/release-it#hooks)).
+- Changed default value of `git.pushRepo` from `"origin"` to `""`. Changes behavior when branch has tracking
+  information and `git.pushRepo` is set to default value. Previously would push to `origin`, now will
+  push to tracked branch.
 
 ## v12
 

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -16,7 +16,7 @@
     "tagArgs": "",
     "push": true,
     "pushArgs": "--follow-tags",
-    "pushRepo": "origin"
+    "pushRepo": ""
   },
   "npm": {
     "publish": true,

--- a/docs/git.md
+++ b/docs/git.md
@@ -28,7 +28,8 @@ The following help pages might be useful:
 
 ## Remote repository
 
-By default, `release-it` uses `"origin"` as the remote name to push to. Use `git.pushRepo` to override this with a
+By default, `release-it` uses branch's tracking information, unless there isn't any, in which case it
+defaults to `"origin"` as the remote name to push to. Use `git.pushRepo` to override this with a
 different remote name, or a different git url.
 
 ## Extra arguments

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -40,8 +40,8 @@ be committed with the release commit, use `--no-git.requireCleanWorkingDir` or c
 If no upstream branch is known to Git, it does not know where to push the release commit and tag to, and halts.
 
 Use `--no-git.requireUpstream` to add `--set-upstream [remote] [branch]` to the `git push` command, where `[remote]` is
-the value of `git.pushRepo` ("origin" by default), and `[branch]` is the name of the current branch. So if the current
-branch is `next` then the full command becomes `git push --follow-tags --set-upstream origin next`.
+the value of `git.pushRepo` ("origin" by default, if no upstream branch), and `[branch]` is the name of the current
+branch. So if the current branch is `next` then the full command becomes `git push --follow-tags --set-upstream origin next`.
 
 Configure `pushRepo` with either a remote name or a Git url to push the release to that remote instead of "origin".
 

--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -163,13 +163,13 @@ class Git extends GitBase {
 
   async push({ args = this.options.pushArgs } = {}) {
     const { pushRepo } = this.options;
-    let upstream = 'origin';
+    let upstream = '';
     if (pushRepo && !this.isRemoteName(pushRepo)) {
       // Use (only) `pushRepo` if it's configured and looks like a url
       upstream = pushRepo;
     } else if (!(await this.hasUpstreamBranch())) {
       // Start tracking upstream branch (`pushRepo` is a name if set)
-      upstream = `--set-upstream ${pushRepo || upstream} ${await this.getBranchName()}`;
+      upstream = `--set-upstream ${pushRepo || 'origin'} ${await this.getBranchName()}`;
     } else if (pushRepo && !invalidPushRepoRe.test(pushRepo)) {
       upstream = pushRepo;
     }

--- a/test/git.js
+++ b/test/git.js
@@ -165,7 +165,22 @@ test.serial('should push to origin', async t => {
   const gitClient = factory(Git);
   const spy = sinon.spy(gitClient.shell, 'exec');
   await gitClient.push();
-  t.is(spy.lastCall.args[0], 'git push  origin');
+  t.is(spy.lastCall.args[0], 'git push  ');
+  const actual = sh.exec('git ls-tree -r HEAD --name-only', { cwd: bare });
+  t.is(actual.trim(), 'file');
+  spy.restore();
+});
+
+test.serial('should push to tracked upstream branch', async t => {
+  const bare = mkTmpDir();
+  sh.exec(`git init --bare ${bare}`);
+  sh.exec(`git clone ${bare} .`);
+  sh.exec(`git remote rename origin upstream`);
+  gitAdd('line', 'file', 'Add file');
+  const gitClient = factory(Git);
+  const spy = sinon.spy(gitClient.shell, 'exec');
+  await gitClient.push();
+  t.is(spy.lastCall.args[0], 'git push  ');
   const actual = sh.exec('git ls-tree -r HEAD --name-only', { cwd: bare });
   t.is(actual.trim(), 'file');
   spy.restore();

--- a/test/shell.js
+++ b/test/shell.js
@@ -16,7 +16,7 @@ test('exec (with context)', async t => {
   const exec = cmd => shell.exec(cmd, { verbose: false }, shell.config.getContext());
   t.is(await exec(''), undefined);
   t.is(await exec('!pwd'), cwd);
-  t.is(await exec('echo ${git.pushRepo}'), 'origin');
+  t.is(await exec('echo ${git.pushArgs}'), '--follow-tags');
   t.is(await exec('echo -*- ${github.tokenRef} -*-'), '-*- GITHUB_TOKEN -*-');
 });
 


### PR DESCRIPTION
When the branch is tracking upstream branch and `git.pushRepo` was
not customized, there should push directly to upstream branch instead
of pushing to `origin` which might not be the one that matches tracking
information or even exist.

Resolves #608