### PR TITLE
Fix scoped packages publish behavior

### DIFF
--- a/docs/npm.md
+++ b/docs/npm.md
@@ -41,21 +41,30 @@ For a pre-release, the default tag is "next". The tag will be derived from the p
 
 ## Public scoped packages
 
-A [scoped package](https://docs.npmjs.com/misc/plugin) (e.g. `@user/package`) is either public or private. To
-[publish scoped packages](https://docs.npmjs.com/misc/plugin#publishing-scoped-packages), make sure this is in
-`package.json`:
+A [scoped package](https://docs.npmjs.com/about-scopes) (e.g. `@user/package`) is either public or private. By default, 
+`npm publish` will publish a scoped package as private. Note that scoped packages requires a paid account.
+
+In order to publish a public scoped package, you can add the following to your release-it config:
 
 ```json
 {
-  "publishConfig": {
-    "access": "public"
+  "npm": {
+    "access": "public" // or "restricted"
   }
 }
 ```
 
-By default, `npm publish` will
-[publish a scoped package as private](https://docs.npmjs.com/creating-and-publishing-private-packages) (requires paid
-account).
+However, this should most likely be specified in your `package.json`: 
+
+```json
+{
+  "publishConfig": {
+    "access": "public" // or "restricted"
+  }
+}
+```
+
+By specifying this in your `package.json`, publishing via `npm` will respect this setting as well. 
 
 ## Two-factor authentication
 

--- a/lib/plugin/npm/npm.js
+++ b/lib/plugin/npm/npm.js
@@ -175,9 +175,9 @@ class npm extends Plugin {
 
   async publish({ otp = this.options.otp, otpCallback } = {}) {
     const { publishPath = '.', access } = this.options;
-    const { name, private: isPrivate, tag = DEFAULT_TAG, isNewPackage } = this.getContext();
+    const { name, private: isPrivate, tag = DEFAULT_TAG } = this.getContext();
     const isScopedPkg = name.startsWith('@');
-    const accessArg = isScopedPkg && (access || (isNewPackage && !isPrivate)) ? `--access ${access || 'public'}` : '';
+    const accessArg = isScopedPkg && access ? `--access ${access}` : '';
     const otpArg = otp ? `--otp ${otp}` : '';
     const dryRunArg = this.global.isDryRun ? '--dry-run' : '';
     if (isPrivate) {

--- a/test/npm.js
+++ b/test/npm.js
@@ -166,10 +166,40 @@ test('should throw if user is not authenticated', async t => {
   exec.restore();
 });
 
-test('should publish scoped package', async t => {
+test('should publish public scoped package as public', async t => {
   const options = { npm: { access: 'public', tag: 'beta' } };
   const npmClient = factory(npm, { options });
   npmClient.setContext({ name: '@scoped/pkg' });
+  const exec = sinon.spy(npmClient.shell, 'exec');
+  await npmClient.publish();
+  t.is(exec.lastCall.args[0].trim(), 'npm publish . --tag beta --access public');
+  exec.restore();
+});
+
+test('should publish a private scoped package as private', async t => {
+  const options = { npm: { access: 'restricted', tag: 'beta' } };
+  const npmClient = factory(npm, { options });
+  npmClient.setContext({ name: '@scoped/pkg' });
+  const exec = sinon.spy(npmClient.shell, 'exec');
+  await npmClient.publish();
+  t.is(exec.lastCall.args[0].trim(), 'npm publish . --tag beta --access restricted');
+  exec.restore();
+});
+
+test('should publish a new private scoped package as NPM would', async t => {
+  const options = { npm: { tag: 'beta' } };
+  const npmClient = factory(npm, { options });
+  npmClient.setContext({ name: '@scoped/pkg', isNewPackage: true });
+  const exec = sinon.spy(npmClient.shell, 'exec');
+  await npmClient.publish();
+  t.is(exec.lastCall.args[0].trim(), 'npm publish . --tag beta');
+  exec.restore();
+});
+
+test('should publish a new public scoped package as public', async t => {
+  const options = { npm: { access: 'public', tag: 'beta' } };
+  const npmClient = factory(npm, { options });
+  npmClient.setContext({ name: '@scoped/pkg', isNewPackage: true });
   const exec = sinon.spy(npmClient.shell, 'exec');
   await npmClient.publish();
   t.is(exec.lastCall.args[0].trim(), 'npm publish . --tag beta --access public');

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -331,7 +331,7 @@ test.serial('should handle private package correctly, bump lockfile', async t =>
   exec.restore();
 });
 
-test.serial('should initially publish non-private scoped npm package publicly', async t => {
+test.serial('should initially publish non-private scoped npm package privately', async t => {
   const { target } = t.context;
   const pkgName = path.basename(target);
   gitAdd(`{"name":"@scope/${pkgName}","version":"1.0.0"}`, 'package.json', 'Add package.json');
@@ -344,7 +344,7 @@ test.serial('should initially publish non-private scoped npm package publicly', 
   await runTasks({}, container);
 
   const npmArgs = getNpmArgs(container.shell.exec.args);
-  t.is(npmArgs[4], 'npm publish . --tag latest --access public');
+  t.is(npmArgs[4], 'npm publish . --tag latest');
   exec.restore();
 });
 


### PR DESCRIPTION
Had three issues here:

* The docs suggested scoped packages would be published as private,
  however this behavior was changed in c3976bf
* The docs show config to be added to the package.json, which can be
  easily misunderstood as what needs to be added to the .release-it.json
  file (all the other examples reference the release-it config)
* The links in the docs were dead

This commit reverts the behavior introduced by c3976bf because the
behavior is surprising and dangerous.

It also updates the documentation to fix the links and show how to
configure release-it first (before the note about a package.json file).