### PR TITLE
feat(git): add support for git url aliases

### DIFF
--- a/lib/plugin/GitBase.js
+++ b/lib/plugin/GitBase.js
@@ -55,7 +55,7 @@ class GitBase extends Plugin {
   async getRemoteUrl() {
     const remoteNameOrUrl = this.options.pushRepo || (await this.getRemote()) || 'origin';
     return this.isRemoteName(remoteNameOrUrl)
-      ? this.exec(`git config --get remote.${remoteNameOrUrl}.url`, { options }).catch(() => null)
+      ? this.exec(`git remote get-url ${remoteNameOrUrl}`, { options }).catch(() => null)
       : remoteNameOrUrl;
   }
 

--- a/test/github.js
+++ b/test/github.js
@@ -66,7 +66,7 @@ test('should release and upload assets', async t => {
 test('should release to enterprise host', async t => {
   const github = factory(GitHub, { options: { github: { tokenRef } } });
   const exec = sinon.stub(github.shell, 'exec').callThrough();
-  exec.withArgs('git config --get remote.origin.url').resolves(`https://github.example.org/user/repo`);
+  exec.withArgs('git remote get-url origin').resolves(`https://github.example.org/user/repo`);
   exec.withArgs('git describe --tags --abbrev=0').resolves(`1.0.0`);
 
   const remote = { api: 'https://github.example.org/api/v3', host: 'github.example.org' };


### PR DESCRIPTION
Hello everyone,

I propose a small improvement for your great tool 😊 

In my git config, I implemented some git url aliases including the following one:
```txt
[url "git@github.com:"]
        insteadOf = "gh:"
```

Which allows me to clone like this: `git clone gh:SuperITMan/stark.git`.

If I want to get the url of my remote with `git remote -v`, I obtain: 

```bash
origin  git@github.com:SuperITMan/stark.git (fetch)
origin  git@github.com:SuperITMan/stark.git (push)
```

But in release-it, currently, when the tool tries to get the remote url, it uses the command `git config --get remote.origin.url` which gives `gh:SuperITMan/stark.git` instead of `git@github.com:SuperITman/stark.git`.

See the error I get when I try to do a release (the url is wrong and GITHUB_TOKEN variable is useless):

```bash
npm run release -- -VV

> stark-srcs@10.0.0 release /home/superitman/GIT/stark
> release-it "-VV"

$ git config --get remote.origin.url
gh:SuperITMan/stark.git
$ git fetch
Enter passphrase for key '/home/superitman/.ssh/<ssh_key_name>':

$ git describe --tags --abbrev=0
10.0.0
$ npm run generate:changelog-recent
> stark-srcs@10.0.0 generate:changelog-recent /home/superitman/GIT/stark
> conventional-changelog -p angular | tail -n +3
octokit users#getAuthenticated
ERROR Could not authenticate with GitHub using environment variable "GITHUB_TOKEN".
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! stark-srcs@10.0.0 release: `release-it "-VV"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the stark-srcs@10.0.0 release script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/superitman/.npm/_logs/2020-03-27T10_03_41_182Z-debug.log
```

The command `git remote get-url <remote_name>` is apparently available since Git 2.7 according to https://stackoverflow.com/a/32991784 