### PR TITLE
Ensure test runner passes latest version to `getChangelog`

### DIFF
--- a/test/util/index.js
+++ b/test/util/index.js
@@ -36,7 +36,7 @@ module.exports.runTasks = async plugin => {
 
   const name = (await plugin.getName()) || '__test__';
   const latestVersion = (await plugin.getLatestVersion()) || '1.0.0';
-  const changelog = (await plugin.getChangelog()) || null;
+  const changelog = (await plugin.getChangelog(latestVersion)) || null;
   const increment = plugin.getContext('increment') || plugin.config.getContext('increment');
   plugin.config.setContext({ name, latestVersion, changelog });
 


### PR DESCRIPTION
Prior to this change the implementation in `lib/tasks.js` passes the latest version in to the `Plugin.prototype.getChangelog` method:

https://github.com/release-it/release-it/blob/81136a214eeb744dd6d6d48626f8a4786a55b39c/lib/tasks.js#L70-L71

However the test runner in `test/util/index.js` did not:

https://github.com/release-it/release-it/blob/81136a214eeb744dd6d6d48626f8a4786a55b39c/test/util/index.js#L38-L39