### PR TITLE
Set `latestTag` and `tagName` on global config in test harness.

### DIFF
--- a/test/util/index.js
+++ b/test/util/index.js
@@ -38,7 +38,7 @@ module.exports.runTasks = async plugin => {
   const latestVersion = (await plugin.getLatestVersion()) || '1.0.0';
   const changelog = (await plugin.getChangelog()) || null;
   const increment = plugin.getContext('increment') || plugin.config.getContext('increment');
-  plugin.config.setContext({ name, latestVersion, changelog });
+  plugin.config.setContext({ name, latestVersion, latestTag: latestVersion, changelog });
 
   const version =
     plugin.getIncrementedVersionCI({ latestVersion, increment }) ||
@@ -48,6 +48,9 @@ module.exports.runTasks = async plugin => {
 
   await plugin.beforeBump();
   await plugin.bump(version);
+
+  plugin.config.setContext({ tagName: version });
+
   await plugin.beforeRelease();
   await plugin.release();
   await plugin.afterRelease();


### PR DESCRIPTION
As of release-it@13.5.3 `latestTag` and `tagName` are available on the global configuration object (aka `this.config` within a plugin instance). These new global config context values make authoring plugins that care about these values (but don't "control" them) much easier.

Unfortunately, prior to these changes they were not setup and available from within the test harness. Since these values are always present when used outside of the test harness having them missing while testing means that plugins are forced to handle fallback scenarios for when they are not set (which is extremely unlikely to happen in reality).

This commit sets `latestTag` and `tagName` in the test harness. It currently uses the values for `latestVersion` and `version` for that (because the test harness does not actually support providing custom global configuration to set `git.tagName` template).