### PR TITLE
Simplify GitHub Actions CI Job Names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+          - ubuntu
+          - windows
+          - macos
         node:
           - 10
           - 12
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
 
     steps:


### PR DESCRIPTION
This effectively removes the (IMHO needless) `-latest` suffix in the names of each of the Cross OS tests. The node versions were cutting off when I was viewing the CI status on prior pull requests.

Before:

![Screen Shot 2020-04-24 at 11 28 56 AM](https://user-images.githubusercontent.com/12637/80229686-cc1fd300-861e-11ea-9d06-333cbc5b3449.png)


After:

![Screen Shot 2020-04-24 at 11 28 16 AM](https://user-images.githubusercontent.com/12637/80229623-b4e0e580-861e-11ea-9144-683706ef5c01.png)
