### PR TITLE
Add Node 14 to GitHub Actions CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         node:
           - 10
           - 12
+          - 14
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} (Node v${{ matrix.node }})


### PR DESCRIPTION
Based on the prior setup it seemed like we only wanted to test LTS versions of Node. Since 14 just came out and _will eventually_ be an LTS, I figured we could add it to the CI setup...