### PR TITLE
Update `shelljs` dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+          - ubuntu
+          - windows
+          - macos
         node:
           - 10
           - 12
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         node:
           - 10
           - 12
+          - 14
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} (Node v${{ matrix.node }})

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "os-name": "3.1.0",
     "parse-json": "5.0.0",
     "semver": "7.3.2",
-    "shelljs": "0.8.3",
+    "shelljs": "0.8.4",
     "supports-color": "7.1.0",
     "update-notifier": "4.1.0",
     "url-join": "4.0.1",

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -36,7 +36,7 @@ module.exports.runTasks = async plugin => {
 
   const name = (await plugin.getName()) || '__test__';
   const latestVersion = (await plugin.getLatestVersion()) || '1.0.0';
-  const changelog = (await plugin.getChangelog()) || null;
+  const changelog = (await plugin.getChangelog(latestVersion)) || null;
   const increment = plugin.getContext('increment') || plugin.config.getContext('increment');
   plugin.config.setContext({ name, latestVersion, changelog });
 


### PR DESCRIPTION
`release-it` currently prints the following warnings in Node 14:

```
(node:32597) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
    at emitCircularRequireWarning (internal/modules/cjs/loader.js:814:11)
    at Object.get (internal/modules/cjs/loader.js:825:5)
    at Object._register [as register] (/Users/daniel/code/quickapp-demo/node_modules/shelljs/src/common.js:453:12)
    at Object.<anonymous> (/Users/daniel/code/quickapp-demo/node_modules/shelljs/src/cat.js:4:8)
    at Module._compile (internal/modules/cjs/loader.js:1185:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1205:10)
    at Module.load (internal/modules/cjs/loader.js:1034:32)
    at Function.Module._load (internal/modules/cjs/loader.js:923:14)
    at Module.require (internal/modules/cjs/loader.js:1074:19)
    at require (internal/modules/cjs/helpers.js:72:18)
```

This is due to [a bug](https://github.com/shelljs/shelljs/issues/991) in `shelljs` which was fixed in the next [patch version `0.8.4`](https://github.com/shelljs/shelljs/releases/tag/v0.8.4).