### PR TITLE
Only update a release with a matching tag name

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -150,15 +150,19 @@ class GitHub extends Release {
 
   async getLatestRelease() {
     const { owner, project: repo } = this.getContext('repo');
+    const { latestTagName } = this.getContext();
     try {
       const options = {
         owner,
         repo
       };
       this.debug(options);
-      const response = await this.client.repos.listReleases({ owner, repo, per_page: 1, page: 1 });
-      this.debug(response.data[0]);
-      return response.data[0];
+      const response = await this.client.repos.listReleases(options);
+      const release = response.data.find(release => {
+        return release.tag_name === latestTagName;
+      });
+      this.debug(release);
+      return release;
     } catch (err) {
       return this.handleError(err, () => {});
     }

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -20,10 +20,11 @@ const interceptListReleases = ({
   tag_name
 } = {}) =>
   nock(api)
-    .get(`/repos/${owner}/${project}/releases?per_page=1&page=1`)
+    .get(`/repos/${owner}/${project}/releases`)
     .reply(200, [
       {
         id: 1,
+        tag_name,
         upload_url: `https://uploads.${host}/repos/${owner}/${project}/releases/1/assets{?name,label}`,
         html_url: `https://${host}/${owner}/${project}/releases/tag/${tag_name}`
       }


### PR DESCRIPTION
Carrying on from #659 I tested a bit further and the current situations means that running
```
release-it \
	--no-npm \
	--no-increment \
	--no-git \
	--github.draft \
	--github.release \
	--github.tagName="pr1-draft" \
	--github.releaseName="pr1 draft" \
	--github.preRelease \
	--github.assets=${ASSETS}
release-it \
	--no-npm \
	--no-increment \
	--no-git \
	--github.draft \
	--github.release \
	--github.tagName="pr2-draft" \
	--github.releaseName="pr2 draft" \
	--github.preRelease \
	--github.assets=${ASSETS}
```
would have the second release update the first despite the tag name and release name being completely different which was unexpected behavior to me, this PR restores the behavior of my original PR where the release is only updated if the names match so that it's possible to have multiple drafts at once.

For my use case it's a draft per PR so that the release artifacts of a PR can be generated/tested and then reused on a merge, which also adds a need to be able to explicitly rename the release to go from the PR naming schema to the versioned `v1.2.3` naming scheme once a PR is merged - I'll open a separate issue for that part but the use case should help clarify things