### PR TITLE
Improve isWorkingDirClean() check for projects with generated code

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -89,7 +89,10 @@ class Git extends GitBase {
   }
 
   isWorkingDirClean() {
-    return this.exec('git diff-index --quiet HEAD --', { options }).then(
+    // Note: the update-index is required here for cases where files may be touched/recreated
+    // during a build/test hook. Git will mark those as potentially changed, but won't diff them
+    // until the index is updated. See also https://github.com/release-it/release-it/issues/687
+    return this.exec('git diff --quiet HEAD', { options }).then(
       () => true,
       () => false
     );

--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -89,9 +89,6 @@ class Git extends GitBase {
   }
 
   isWorkingDirClean() {
-    // Note: the update-index is required here for cases where files may be touched/recreated
-    // during a build/test hook. Git will mark those as potentially changed, but won't diff them
-    // until the index is updated. See also https://github.com/release-it/release-it/issues/687
     return this.exec('git diff --quiet HEAD', { options }).then(
       () => true,
       () => false


### PR DESCRIPTION
Fix for #687

I tried to add some additional test coverage, but for some reason the behavior which I can reliably reproduce in a node terminal (see notes in #687) was only inconsistently reproducible in the tests I tried. I'm not yet clear what it is about the testing environment that causes this, but the existing tests show that the change still works for existing cases, so perhaps that's good enough?