### PR TITLE
Added support to increase existing prerelease version by patch, minor…

### DIFF
--- a/lib/plugin/version/Version.js
+++ b/lib/plugin/version/Version.js
@@ -103,12 +103,11 @@ class Version extends Plugin {
       return increment;
     }
 
-    const _isPreRelease = isPreRelease || (increment || '').startsWith('pre');
-    if (_isPreRelease && latestIsPreRelease) {
+    if (isPreRelease && !increment && latestIsPreRelease) {
       return semver.inc(latestVersion, 'prerelease', preReleaseId);
     }
 
-    const normalizedType = RELEASE_TYPES.includes(increment) && _isPreRelease ? `pre${increment}` : increment;
+    const normalizedType = RELEASE_TYPES.includes(increment) && isPreRelease ? `pre${increment}` : increment;
     if (ALL_RELEASE_TYPES.includes(normalizedType)) {
       return semver.inc(latestVersion, normalizedType, preReleaseId);
     }

--- a/test/version.js
+++ b/test/version.js
@@ -38,7 +38,7 @@ test('should increment latest version (coerce)', t => {
 
 test('should increment version (pre-release continuation)', t => {
   const v = factory(Version);
-  t.is(v.incrementVersion({ latestVersion: '1.2.3-alpha.0', increment: 'prepatch' }), '1.2.3-alpha.1');
+  t.is(v.incrementVersion({ latestVersion: '1.2.3-alpha.0', increment: 'prepatch' }), '1.2.4-0');
 });
 
 test('should increment version (prepatch)', t => {
@@ -51,6 +51,27 @@ test('should increment version (normalized)', t => {
   t.is(
     v.incrementVersion({ latestVersion: '1.2.3', increment: 'patch', preReleaseId: 'alpha', isPreRelease: true }),
     '1.2.4-alpha.0'
+  );
+});
+
+test('should increment version (prepatch on prerelease version)', t => {
+  const v = factory(Version);
+  t.is(
+    v.incrementVersion({ latestVersion: '1.2.3-alpha.5', increment: 'prepatch', preReleaseId: 'next' }),
+    '1.2.4-next.0'
+  );
+});
+
+test('should increment version (normalized on prerelease version)', t => {
+  const v = factory(Version);
+  t.is(
+    v.incrementVersion({
+      latestVersion: '1.2.3-alpha.5',
+      increment: 'patch',
+      preReleaseId: 'next',
+      isPreRelease: true
+    }),
+    '1.2.4-next.0'
   );
 });
 


### PR DESCRIPTION
PR for issue #707 

I've adapted the handling of prerelease versions and added two additional tests.

Futhermore I had to change an existing test. Previously if release-it was executed with prepatch on a prerelease version only the prerelease number was increased. Now the patch version and the prerelease suffix is adapted. I think this is in line with semver but I am not sure if it will affect other use cases/users.