### PR TITLE
Fix prerelease continuation increased patch version in CI mode

### DIFF
--- a/lib/plugin/version/Version.js
+++ b/lib/plugin/version/Version.js
@@ -63,8 +63,7 @@ class Version extends Plugin {
 
   getIncrementedVersionCI(options) {
     const { isCI } = this.config;
-    options.increment = options.increment == null && isCI ? 'patch' : options.increment;
-    return this.incrementVersion(options);
+    return this.incrementVersion(options, isCI);
   }
 
   async getIncrementedVersion(options) {
@@ -93,7 +92,7 @@ class Version extends Plugin {
     return Boolean(semver.valid(version));
   }
 
-  incrementVersion({ latestVersion, increment, isPreRelease, preReleaseId }) {
+  incrementVersion({ latestVersion, increment, isPreRelease, preReleaseId }, isCI) {
     if (increment === false) return latestVersion;
 
     const latestIsPreRelease = this.isPreRelease(latestVersion);
@@ -109,6 +108,10 @@ class Version extends Plugin {
 
     if (isPreRelease && !increment && latestIsPreRelease) {
       return semver.inc(latestVersion, 'prerelease', preReleaseId);
+    }
+
+    if (isCI && !increment) {
+      return semver.inc(latestVersion, 'patch');
     }
 
     const normalizedType = RELEASE_TYPES.includes(increment) && isPreRelease ? `pre${increment}` : increment;

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -106,7 +106,7 @@ test.serial('should instantiate plugins and execute all release-cycle methods', 
     t.is(myLocalPlugin[method].callCount, 1);
   });
 
-  const incrementBase = { latestVersion: '0.0.0', increment: 'patch', isPreRelease: false, preReleaseId: undefined };
+  const incrementBase = { latestVersion: '0.0.0', increment: undefined, isPreRelease: false, preReleaseId: undefined };
   t.deepEqual(myPlugin.getIncrement.firstCall.args[0], incrementBase);
   t.deepEqual(myPlugin.getIncrementedVersionCI.firstCall.args[0], incrementBase);
   t.deepEqual(myLocalPlugin.getIncrementedVersionCI.firstCall.args[0], incrementBase);

--- a/test/version.js
+++ b/test/version.js
@@ -15,11 +15,26 @@ test('isPreRelease', t => {
   t.is(v.isPreRelease('1.0.0'), false);
 });
 
+test('getIncrementedVersionCI should default increment to patch if no increment is given', t => {
+  const v = factory(Version);
+  t.is(v.getIncrementedVersionCI({ latestVersion: '2.0.0', increment: null}), '2.0.1');
+});
+
+test('interactive and ci mode should return the same version if no increment is given (prerelease continuation, issue #714)', async t => {
+  const v = factory(Version);
+  const options = { latestVersion: '2.0.0-beta.1', increment: null, preReleaseId: 'rc', isPreRelease: true};
+  const resultInteractiveMode = await v.getIncrementedVersion(options);
+  t.is(resultInteractiveMode, '2.0.0-rc.0');
+  const resultCiMode = v.getIncrementedVersionCI(options);
+  t.is(resultInteractiveMode, resultCiMode);
+});
+
 test('should increment latest version', t => {
   const v = factory(Version);
   const latestVersion = '1.0.0';
   t.is(v.incrementVersion({ latestVersion, increment: false }), '1.0.0');
   t.is(v.incrementVersion({ latestVersion, increment: null }), undefined);
+  t.is(v.incrementVersion({ latestVersion, increment: null }, true), '1.0.1');
   t.is(v.incrementVersion({ latestVersion, increment: 'foo' }), undefined);
   t.is(v.incrementVersion({ latestVersion, increment: 'patsj' }), undefined);
   t.is(v.incrementVersion({ latestVersion, increment: 'a.b.c' }), undefined);


### PR DESCRIPTION
@webpro This PR tries to solve #714 - which I've introduced via #707 

Problem was that the 'patch' default in the CI mode previously did not had an effect in a prerelease continuation scenario. With #707 the default patch increment is applied.

To solve this the prelease shortcut has to be detected first. Only if it's not the prerelease shortcut the increment can be set to 'patch' in CI mode. To be able to implement this evaluation order I added a optional isCI flag to the incrementVersion method.

I also added some additional tests to verify the fix.