### PR TITLE
Update the config.js library file to look for release-it.cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ Out of the box, release-it has sane defaults, and [plenty of options](./config/r
 (only) the options to override in a configuration file. This is where release-it looks for configuration:
 
 - `.release-it.json`
-- `.release-it.js` (export the configuration object: `module.exports = {}`)
+- `.release-it.js` (or `.cjs`; export the configuration object: `module.exports = {}`)
 - `.release-it.yaml` (or `.yml`)
 - `.release-it.toml`
 - `package.json` (in the `release-it` property)
 
-Use `--config` to use another path for the configuration file. An example `.release-it.json`:
+Use `--config` to use another path for the configuration file.
+
+An example `.release-it.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ Out of the box, release-it has sane defaults, and [plenty of options](./config/r
 - `.release-it.toml`
 - `package.json` (in the `release-it` property)
 
-Use `--config` to use another path for the configuration file.
-
-An example `.release-it.json`:
+Use `--config` to use another path for the configuration file. An example `.release-it.json`:
 
 ```json
 {

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ const searchPlaces = [
   'package.json',
   '.release-it.json',
   '.release-it.js',
+  '.release-it.cjs',
   '.release-it.yaml',
   '.release-it.yml',
   '.release-it.toml'


### PR DESCRIPTION
Hi there. This is a super-simple pull request that adds to the config.js library file to look for `release-it.cjs` in addition to `release-it.js` as a possible configuration file.

In our company we use `release-it` to help automate versioning and packaging a bunch of different repositories. Most of the repos use the same release configuration, and as part of a general consolidation effort we'd like to look at a single configuration with the ability to override it if necessary.

We trying out a new mechanism where we are storing the `release-it` configuration in a `.js` file and putting in a little bit of logic to make overrides dead simple. 

A typical configuration file in one of the repos might look something like this:

```js
const releaseItConfig = require('@buildinglink/js-build-tools/release-it-base-configuration')

const releaseItOverrides = {
  // uncomment the next line to prevent any automatic updates to imported packages
  lockPackageVersions: true
}

module.exports = releaseItConfig(releaseItOverrides)
```

Neat! Our only problem? Most of our repos are set up as modules, so in order to keep with using CommonJS for `release-it` configurations we have to use `.cjs` as the file extension. Hence this PR. ;-) The `cosmiconfig` package that the `config.js` file is using seems to follow a similar approach.

Thank you for your consideration, and thank you for all of the hard work you've put into `release-it`! We love it!