### PR TITLE
Move changelog generation to after version bump

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -65,7 +65,6 @@ const runTasks = async (opts, di) => {
 
     const name = await reduceUntil(plugins, plugin => plugin.getName());
     const latestVersion = await reduceUntil(plugins, plugin => plugin.getLatestVersion());
-    const changelog = await reduceUntil(plugins, plugin => plugin.getChangelog(latestVersion));
 
     const incrementBase = { latestVersion, increment, isPreRelease, preReleaseId };
 
@@ -82,7 +81,9 @@ const runTasks = async (opts, di) => {
       process.exit(0);
     }
 
-    config.setContext({ name, latestVersion, version, changelog });
+    config.setContext({ name, latestVersion, version });
+    const changelog = await reduceUntil(plugins, plugin => plugin.getChangelog(latestVersion));
+    config.setContext({ changelog });
 
     const action = config.isUpdate ? 'update' : 'release';
     const suffix = version && !config.isUpdate ? `${latestVersion}...${version}` : `currently at ${latestVersion}`;


### PR DESCRIPTION
Changelog providing plugins can use the incremented version for generation