### PR TITLE
feat: Adding certificateAuthorityFile option for GitLab releases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 8,
+    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "extends": ["eslint:recommended", "plugin:ava/recommended", "prettier"],

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -47,6 +47,7 @@
     "releaseNotes": null,
     "tokenRef": "GITLAB_TOKEN",
     "tokenHeader": "Private-Token",
+    "certificateAuthorityFile": null,
     "assets": null,
     "origin": null,
     "skipChecks": false

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -60,6 +60,21 @@ download from the project's releases page. Example:
 The `origin` can be set to a string such as `"http://example.org:3000"` to use a different origin from what would be
 derived from the Git url (e.g. to use `http` over the default `https://${repo.host}`).
 
+## Private CA Authority
+
+If you're running your own GitLab instance with an HTTPS certificate issued by a private certificate Authority, you can
+specify the root CA certificate with `certificateAuthorityFile`, for example:
+
+```json
+{
+  "gitlab": {
+    "release": true,
+    "tokenHeader": "PRIVATE-TOKEN",
+    "certificateAuthorityFile": "./my-root-ca.crt"
+  }
+}
+```
+
 ## Update the latest release
 
 The latest GitLab release can be updated, e.g. to update the releases notes or add release assets.

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -32,7 +32,8 @@ class GitLab extends Release {
       headers: {
         'user-agent': 'webpro/release-it',
         [tokenHeader]: this.token
-      }
+      },
+      ...this.certificateAuthorityOption
     });
     return this._client;
   }
@@ -71,7 +72,7 @@ class GitLab extends Release {
     if (this.config.isDryRun) return true;
     const endpoint = `user`;
     try {
-      const { id, username } = await this.request(endpoint, { method: 'GET', ...this.certificateAuthorityOption });
+      const { id, username } = await this.request(endpoint, { method: 'GET' });
       this.setContext({ user: { id, username } });
       return true;
     } catch (err) {
@@ -85,7 +86,7 @@ class GitLab extends Release {
     const { id, user } = this.getContext();
     const endpoint = `projects/${id}/members/all/${user.id}`;
     try {
-      const { access_level } = await this.request(endpoint, { method: 'GET', ...this.certificateAuthorityOption });
+      const { access_level } = await this.request(endpoint, { method: 'GET' });
       return access_level && access_level >= 30;
     } catch (err) {
       this.debug(err);
@@ -93,7 +94,7 @@ class GitLab extends Release {
         // Using another endpoint, since "/projects/:id/members/all/:user_id" was introduced in v12.4
         const endpoint = `projects/${id}/members/${user.id}`;
         try {
-          const { access_level } = await this.request(endpoint, { method: 'GET', ...this.certificateAuthorityOption });
+          const { access_level } = await this.request(endpoint, { method: 'GET' });
           return access_level && access_level >= 30;
         } catch (err) {
           this.debug(err);
@@ -149,8 +150,7 @@ class GitLab extends Release {
         name,
         tag_name: tagName,
         description
-      },
-      ...this.certificateAuthorityOption
+      }
     };
 
     if (this.assets.length) {
@@ -177,7 +177,7 @@ class GitLab extends Release {
 
     const body = new FormData();
     body.append('file', fs.createReadStream(filePath));
-    const options = { body, ...this.certificateAuthorityOption };
+    const options = { body };
 
     try {
       const body = await this.request(endpoint, options);

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -16,6 +16,10 @@ class GitLab extends Release {
     super(...args);
     this.registerPrompts(prompts);
     this.assets = [];
+    const { certificateAuthorityFile } = this.options;
+    this.certificateAuthorityOption = certificateAuthorityFile
+      ? { https: { certificateAuthority: fs.readFileSync(certificateAuthorityFile) } }
+      : {};
   }
 
   get client() {
@@ -67,7 +71,7 @@ class GitLab extends Release {
     if (this.config.isDryRun) return true;
     const endpoint = `user`;
     try {
-      const { id, username } = await this.request(endpoint, { method: 'GET' });
+      const { id, username } = await this.request(endpoint, { method: 'GET', ...this.certificateAuthorityOption });
       this.setContext({ user: { id, username } });
       return true;
     } catch (err) {
@@ -81,7 +85,7 @@ class GitLab extends Release {
     const { id, user } = this.getContext();
     const endpoint = `projects/${id}/members/all/${user.id}`;
     try {
-      const { access_level } = await this.request(endpoint, { method: 'GET' });
+      const { access_level } = await this.request(endpoint, { method: 'GET', ...this.certificateAuthorityOption });
       return access_level && access_level >= 30;
     } catch (err) {
       this.debug(err);
@@ -89,7 +93,7 @@ class GitLab extends Release {
         // Using another endpoint, since "/projects/:id/members/all/:user_id" was introduced in v12.4
         const endpoint = `projects/${id}/members/${user.id}`;
         try {
-          const { access_level } = await this.request(endpoint, { method: 'GET' });
+          const { access_level } = await this.request(endpoint, { method: 'GET', ...this.certificateAuthorityOption });
           return access_level && access_level >= 30;
         } catch (err) {
           this.debug(err);
@@ -145,7 +149,8 @@ class GitLab extends Release {
         name,
         tag_name: tagName,
         description
-      }
+      },
+      ...this.certificateAuthorityOption
     };
 
     if (this.assets.length) {
@@ -172,7 +177,7 @@ class GitLab extends Release {
 
     const body = new FormData();
     body.append('file', fs.createReadStream(filePath));
-    const options = { body };
+    const options = { body, ...this.certificateAuthorityOption };
 
     try {
       const body = await this.request(endpoint, options);


### PR DESCRIPTION
When running a private GitLab instance protected with a certificate issued by a private certificate authority, you can now specify a root CA certificate file with `gitlab.certificateAuthorityFile` option.