### PR TITLE
Fix: example plugin reads file as string

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -109,7 +109,7 @@ This minimal example reads the current version from a `VERSION` file, and bumps 
 ```js
 class MyPlugin extends Plugin {
   getLatestVersion() {
-    return fs.readFileSync('./VERSION').trim();
+    return fs.readFileSync('./VERSION', 'utf8').trim();
   }
   bump(version) {
     this.version = version;


### PR DESCRIPTION
Before it was getting a buffer, but it was meant to get a string, so an encoding needs to be specified.