### PR TITLE
feat(status): remove whitespace from front of status

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -155,7 +155,7 @@ class Git extends GitBase {
   }
 
   status() {
-    return this.exec('git status --short --untracked-files=no', { options }).catch(() => null);
+    return this.exec('git status --short --untracked-files=no', { options }).then(status => status.replace(/^\s+/gm, '')).catch(() => null);
   }
 
   commit({ message = this.options.commitMessage, args = this.options.commitArgs } = {}) {


### PR DESCRIPTION
This is an OCD issue, but `git status --short --untracked-files=no` adds a whitespace in front of every line except the first one. It would be nice to uniformly indent the changeset or like with this PR remove the front whitespace from every line of the the git status.

This PR will remove the spaces before each M:
![image](https://user-images.githubusercontent.com/1834664/124025618-f7573c80-d9f0-11eb-8f51-67f26d1380a3.png)
