### PR TITLE
Changed git docs with correct hook

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -156,5 +156,5 @@ In case you need even more customizations, here is some inspiration:
 }
 ```
 
-Since the `after:git:release` hook runs after the Git commands, the `git.push` can be disabled, and replaced by a custom
+Since the `after:release` hook runs after the Git commands, the `git.push` can be disabled, and replaced by a custom
 script.


### PR DESCRIPTION
In previous version hooks won't fire with `push:false` option.

```Note that hooks like after:git:release will not run when either the git push failed, or when it is configured not to be executed (e.g. git.push: false). See execution order for more details on execution order of plugin lifecycle methods.```