### PR TITLE
chore(deps): update strip-ansi

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "prettier": "2.4.1",
     "proxyquire": "2.1.3",
     "sinon": "11.1.2",
-    "strip-ansi": "6.0.0"
+    "strip-ansi": "6.0.1"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
fixes CVE-2021-3807

Refer: https://github.com/chalk/strip-ansi/releases/tag/v6.0.1
