### PR TITLE
feat : add a host info when generating web url

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -295,8 +295,11 @@ class GitHub extends Release {
   }
 
   generateWebUrl() {
+    const host = this.options.host || this.getContext('repo.host');
+    const isGitHub = host === 'github.com';
+
     const options = this.getOctokitReleaseOptions();
-    return newGithubReleaseUrl({
+    const url = newGithubReleaseUrl({
       user: options.owner,
       repo: options.repo,
       tag: options.tag_name,
@@ -304,6 +307,7 @@ class GitHub extends Release {
       title: options.name,
       body: options.body
     });
+    return isGitHub ? url : url.replace('github.com', host);
   }
 
   async createWebRelease() {


### PR DESCRIPTION
Hi, there 👋
I'm using this package in a Github enterprise.

When I use [github release](https://github.com/release-it/release-it/blob/master/docs/github-releases.md) automatically, It's working well.
But if it's manual, The generated url is always github link. (not enterprise link)
So I added host information to `generateWebUrl` function.

For a similar code convention, I referred to the following.
https://github.com/release-it/release-it/blob/7286e6ec39a00c4e88a586cb0dd420218f690c4e/lib/plugin/github/GitHub.js#L152-L153

Thank you for your hard work.