### PR TITLE
Add `gitlab.milestones` option to associate milestones with a release

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -49,6 +49,7 @@
     "release": false,
     "releaseName": "Release ${version}",
     "releaseNotes": null,
+    "milestones": [],
     "tokenRef": "GITLAB_TOKEN",
     "tokenHeader": "Private-Token",
     "certificateAuthorityFile": null,

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -40,6 +40,20 @@ An example:
 
 See [Changelog](./changelog.md) for more information about generating changelogs/release notes.
 
+## Milestones
+
+To associate one or more milestones with a GitLab release, set the `gitlab.milestones` option to an array of the
+titles of the corresponding milestones, for example:
+
+```json
+{
+  "gitlab": {
+    "release": true,
+    "milestones": ["${version}"]
+  }
+}
+```
+
 ## Attach binary assets
 
 To upload binary release assets with a GitLab release (such as compiled executables, minified scripts, documentation),

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -131,13 +131,14 @@ class GitLab extends Release {
   }
 
   async createRelease() {
-    const { releaseName } = this.options;
+    const { releaseName, milestones } = this.options;
     const { tagName } = this.config.getContext();
     const { id, releaseNotes, repo, origin } = this.getContext();
     const { isDryRun } = this.config;
     const name = format(releaseName, this.config.getContext());
     const description = releaseNotes || '-';
     const releaseUrl = `${origin}/${repo.repository}/-/releases`;
+    const formattedMilestones = (milestones || []).map(milestone => format(milestone, this.config.getContext()));
 
     this.log.exec(`gitlab releases#createRelease "${name}" (${tagName})`, { isDryRun });
 
@@ -159,6 +160,10 @@ class GitLab extends Release {
       options.json.assets = {
         links: this.assets
       };
+    }
+
+    if (formattedMilestones.length) {
+      options.json.milestones = formattedMilestones;
     }
 
     try {

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -55,7 +55,8 @@ test.serial('should upload assets and release', async t => {
       release: true,
       releaseName: 'Release ${version}',
       releaseNotes: 'echo Custom notes',
-      assets: 'test/resources/file-v${version}.txt'
+      assets: 'test/resources/file-v${version}.txt',
+      milestones: ['${version}', '${latestVersion} UAT']
     }
   };
   const gitlab = factory(GitLab, { options });
@@ -76,7 +77,8 @@ test.serial('should upload assets and release', async t => {
             url: `${pushRepo}/uploads/7e8bec1fe27cc46a4bc6a91b9e82a07c/file-v2.0.1.txt`
           }
         ]
-      }
+      },
+      milestones: ['2.0.1', '2.0.0 UAT']
     }
   });
 


### PR DESCRIPTION
Closes #871 