### PR TITLE
test: fix CI test for different Node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,10 @@ jobs:
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
       - run: git config --global user.name User
       - run: git config --global user.email user@example.org
       - run: npm install


### PR DESCRIPTION
I believe CI was failing to test the different Node versions that should be supported because of this missing step.

https://github.com/actions/setup-node#usage

Related to: #886

The Node 10 test should fail for this PR until #887 is merged.