### PR TITLE
chore: use `npm ci`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: git config --global user.name User
       - run: git config --global user.email user@example.org
-      - run: npm install
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
This command is safer to use in CI for installing dependencies: https://docs.npmjs.com/cli/v8/commands/npm-ci