### PR TITLE
chore: use NPM `engine-strict=true`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+engine-strict=true


### PR DESCRIPTION
Add NPM config [engine-strict=true](https://docs.npmjs.com/cli/v8/using-npm/config#engine-strict) to prevent the `npm install` step during CI from succeeding if some dependencies aren't compatible with the Node version we are testing.

It turns out there are still numerous incompatibilities with Node 10 which release-it is supposed to support, as you can see from the Node 10 CI warnings output:

```
Run npm install
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated gulp-header@1.8.12: Removed event-stream from gulp-header
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN notsup Unsupported engine for compress-brotli@1.3.6: wanted: {"node":">= 12"} (current: {"node":"10.24.1","npm":"6.14.12"})
npm WARN notsup Not compatible with your version of node/npm: compress-brotli@1.3.6
npm WARN notsup Unsupported engine for lru-cache@7.8.0: wanted: {"node":">=12"} (current: {"node":"10.24.1","npm":"6.14.12"})
npm WARN notsup Not compatible with your version of node/npm: lru-cache@7.8.0
npm WARN notsup Unsupported engine for eslint-plugin-ava@13.2.0: wanted: {"node":">=12.22 <13 || >=14.17 <15 || >=16.4"} (current: {"node":"10.24.1","npm":"6.14.12"})
npm WARN notsup Not compatible with your version of node/npm: eslint-plugin-ava@13.2.0
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.2 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN notsup Unsupported engine for espree@9.3.1: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"10.24.1","npm":"6.14.12"})
npm WARN notsup Not compatible with your version of node/npm: espree@9.3.1
npm WARN notsup Unsupported engine for eslint-visitor-keys@3.3.0: wanted: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"} (current: {"node":"10.24.1","npm":"6.14.12"})
npm WARN notsup Not compatible with your version of node/npm: eslint-visitor-keys@3.3.0
```

By default, npm only warns on these incompatibilities, which is why we need the config option. Yarn fails on them by default, which is how I noticed release-it still lacked Node 10 support when trying to install it in my repository:

```
yarn install v1.22.18
error lru-cache@7.8.0: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.24.1"
```

https://www.stefanjudis.com/today-i-learned/prevent-npm-install-for-not-supported-node-js-versions/#how-to-prevent-%60npm-install%60-with-an-unsupported-node.js-version

In order for CI in this PR to succeed, some dependencies will need to be downgraded.

Follow-up to https://github.com/release-it/release-it/pull/888 https://github.com/release-it/release-it/issues/886