### PR TITLE
Fixes github.proxy not working (#863)

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -11,6 +11,7 @@ const pkg = require('../../../package.json');
 const { format, parseVersion, e } = require('../../util');
 const Release = require('../GitRelease');
 const prompts = require('./prompts');
+const ProxyAgent = require('proxy-agent');
 
 const docs = 'https://git.io/release-it-github';
 
@@ -167,7 +168,7 @@ class GitHub extends Release {
     };
 
     if (proxy) {
-      options.proxy = proxy;
+      options.request.agent = new ProxyAgent(proxy);
     }
 
     const client = new Octokit(options);

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "os-name": "4.0.1",
     "parse-json": "5.2.0",
     "promise.allsettled": "1.0.5",
+    "proxy-agent": "5.0.0",
     "semver": "7.3.5",
     "shelljs": "0.8.5",
     "update-notifier": "5.1.0",


### PR DESCRIPTION
Based on a recent change in Octokits docs[1], in order for it to use a
configured proxy you must pass another request.agent into the Octokit
constructor. This change adds the `proxy-agent` lib as suggested by
Octokits docs.

Note that with this implmentation, the `http_proxy` or `https_proxy`
environment variables alone will NOT work. Instead one must explicitly
set the value in the `github.proxy` option passed to release-it. This is
to stay inline with current behavior[2].

[1] https://github.com/octokit/octokit.js/commit/2090c85b5addf33b93dac74930312593622c08b8
[2] https://github.com/release-it/release-it/blob/14.14.2/docs/github-releases.md#proxy