### PR TITLE
Replace all `git.io` links with their actual URLs

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -11,7 +11,7 @@ const invalidPushRepoRe = /^\S+@/;
 const options = { write: false };
 const fixArgs = args => (args ? (typeof args === 'string' ? args.split(' ') : args) : []);
 
-const docs = 'https://git.io/release-it-git';
+const docs = 'https://github.com/release-it/release-it/blob/master/docs/git.md';
 
 const isGitRepo = () =>
   execa('git', ['rev-parse', '--git-dir']).then(

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -14,7 +14,7 @@ import prompts from './prompts.js';
 
 const pkg = readJSON(new URL('../../../package.json', import.meta.url));
 
-const docs = 'https://git.io/release-it-github';
+const docs = 'https://github.com/release-it/release-it/blob/master/docs/github-releases.md';
 
 const RETRY_CODES = [408, 413, 429, 500, 502, 503, 504, 521, 522, 524];
 

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -9,7 +9,7 @@ import Release from '../GitRelease.js';
 import { format, e } from '../../util.js';
 import prompts from './prompts.js';
 
-const docs = 'https://git.io/release-it-gitlab';
+const docs = 'https://github.com/release-it/release-it/blob/master/docs/gitlab-releases.md';
 
 const noop = Promise.resolve();
 

--- a/lib/plugin/npm/npm.js
+++ b/lib/plugin/npm/npm.js
@@ -5,7 +5,7 @@ import Plugin from '../Plugin.js';
 import { hasAccess, rejectAfter, parseVersion, readJSON, e } from '../../util.js';
 import prompts from './prompts.js';
 
-const docs = 'https://git.io/release-it-npm';
+const docs = 'https://github.com/release-it/release-it/blob/master/docs/npm.md';
 
 const options = { write: false };
 


### PR DESCRIPTION
Replace the `git.io` links with their actual URL.

GitHub has announced that [all links on `git.io` will stop redirecting after April 29, 2022](https://github.blog/changelog/2022-04-25-git-io-deprecation/). Although seem to change their mind, GitHub describes in a way that only `git.io` links in print documentation and research papers will retain services. And it is not guaranteed that `git.io` will not stop providing service in the future.