### PR TITLE
feat(git): make commitMessage optional parameter in git commit

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -168,7 +168,8 @@ class Git extends GitBase {
 
   commit({ message = this.options.commitMessage, args = this.options.commitArgs } = {}) {
     const msg = format(message, this.config.getContext());
-    return this.exec(['git', 'commit', '--message', msg, ...fixArgs(args)]).then(
+    const commitMessageArgs = msg ? ['--message', msg] : [];
+    return this.exec(['git', 'commit', ...commitMessageArgs, ...fixArgs(args)]).then(
       () => this.setContext({ isCommitted: true }),
       err => {
         this.debug(err);

--- a/test/git.js
+++ b/test/git.js
@@ -140,6 +140,27 @@ test.serial('should commit, tag and push with extra args', async t => {
   stub.restore();
 });
 
+test.serial('should commit without message if not provided', async t => {
+  const bare = mkTmpDir();
+  sh.exec(`git init --bare ${bare}`);
+  sh.exec(`git clone ${bare} .`);
+  gitAdd('line', 'file', 'Add file');
+  const options = {
+    git: { commitArgs: ['--amend', '--no-edit', '--no-verify'], tagArgs: ['-T', 'foo'], pushArgs: ['-U', 'bar', '-V'] }
+  };
+  const gitClient = factory(Git, { options });
+  const stub = sinon.stub(gitClient.shell, 'exec').resolves();
+  await gitClient.stage('package.json');
+  await gitClient.commit();
+  await gitClient.tag({ name: 'v1.2.4', annotation: 'Release v1.2.4' });
+  await gitClient.push();
+  t.deepEqual(stub.secondCall.args[0], ['git', 'commit', '--amend', '--no-edit', '--no-verify']);
+  t.is(stub.thirdCall.args[0][5], '-T');
+  t.is(stub.thirdCall.args[0][6], 'foo');
+  t.true(stub.lastCall.args[0].join(' ').includes('-U bar -V'));
+  stub.restore();
+});
+
 test.serial('should commit and tag with quoted characters', async t => {
   const bare = mkTmpDir();
   sh.exec(`git init --bare ${bare}`);


### PR DESCRIPTION
Due to git.commitMessage being optional t is now possible to amend previous commit instead of
creating a new one.

Example usage:
release-it minor --git.commitArgs='--amend --no-edit' --git.commitMessage=''

fix #907