### PR TITLE
fix: Fixes exports to correctly export test utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "type": "module",
   "exports": {
     ".": "./lib/index.js",
-    "./test/util.js": "./test/util/index.js"
+    "./test/util/index.js": "./test/util/index.js"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This change slightly adjusts the exports in this repo's package.json in order to expose the required test utilities to consumers.

While the alias provided in https://github.com/release-it/release-it/commit/529bc1fde988515079efdb0a8bd2e0fc7360c17e technically works for ESM consumers, it won't work for CJS consumers as that path isn't a real path on disc.

Relates to #920 and tweaks https://github.com/release-it/release-it/commit/529bc1fde988515079efdb0a8bd2e0fc7360c17e to use correct path.