### PR TITLE
Updates README with new plugin package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ Since v11, release-it can be extended in many, many ways. Here are some plugins:
 | [@release-it/bumper](https://github.com/release-it/bumper)                                 | Read & write the version from/to any file                                     |
 | [@release-it/conventional-changelog](https://github.com/release-it/conventional-changelog) | Provides recommended bump, conventional-changelog, and updates `CHANGELOG.md` |
 | [@release-it/keep-a-changelog](https://github.com/release-it/keep-a-changelog)             | Maintain CHANGELOG.md using the Keep a Changelog standards                    |
-| [release-it-lerna-changelog](https://github.com/rwjblue/release-it-lerna-changelog)        | Integrates lerna-changelog into the release-it pipeline                       |
-| [release-it-yarn-workspaces](https://github.com/rwjblue/release-it-yarn-workspaces)        | Releases each of your projects configured workspaces                          |
+| [@release-it-plugins/lerna-changelog](https://github.com/@release-it-plugins/lerna-changelog)| Integrates lerna-changelog into the release-it pipeline                       |
+| [@release-it-plugins/workspaces](https://github.com/@release-it-plugins/workspaces)        | Releases each of your projects configured workspaces                          |
 | [release-it-calver-plugin](https://github.com/casmith/release-it-calver-plugin)            | Enables Calendar Versioning (calver) with release-it                          |
 | [@grupoboticario/news-fragments](https://github.com/grupoboticario/news-fragments)         | An easy way to generate your changelog file                                   |
 | [@j-ulrich/release-it-regex-bumper](https://github.com/j-ulrich/release-it-regex-bumper)   | Regular expression based version read/write plugin for release-it             |


### PR DESCRIPTION
We've moved two plugin packages under a new org, `@release-it-plugins`, and renamed them. This PR updates the README to reflect those renames.