### PR TITLE
Security issue fix: GHSA-vp56-6g26-6827

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lodash": "4.17.21",
     "mime-types": "2.1.35",
     "new-github-release-url": "2.0.0",
-    "node-fetch": "3.2.9",
+    "node-fetch": "3.2.10",
     "open": "8.4.0",
     "ora": "6.1.2",
     "os-name": "5.0.1",


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-vp56-6g26-6827

Still need to be compiled/tested and a new version released.

The node-fetch change is minor and should not have any impact. See: https://github.com/node-fetch/node-fetch/pull/1611/files