### PR TITLE
fix: use spec'ed formdata

### DIFF
--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import got from 'got';
 import { globby } from 'globby';
-import FormData from 'form-data';
+import { FormData, fileFromSync } from 'node-fetch';
 import allSettled from 'promise.allsettled';
 import _ from 'lodash';
 import Release from '../GitRelease.js';
@@ -232,7 +232,7 @@ class GitLab extends Release {
     const endpoint = `projects/${id}/uploads`;
 
     const body = new FormData();
-    body.append('file', fs.createReadStream(filePath));
+    body.set('file', fileFromSync(filePath));
     const options = { body };
 
     try {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "chalk": "5.1.2",
     "cosmiconfig": "8.0.0",
     "execa": "6.1.0",
-    "form-data": "4.0.0",
     "git-url-parse": "13.1.0",
     "globby": "13.1.2",
     "got": "12.5.3",


### PR DESCRIPTION
This PR remove the dependency of form-data package

`FormData` exists built in to NodeJS now in v18+ now.
Both `got` and `node-fetch` support encoding a spec'ed `FormData` themself now, and the `form-data` package is now considered as legacy by `node-fetch` and `got`s standards. `form-data` haven't been updated for a long while and it lacks many methods and don't really follow the specification.

`node-fetch` ships with a polyfilled FormData and ways to get Blob/File like objects backed up by the filesystem that is read lazily when needed (thanks to the `fetch-blob` package). The native FormData provided by NodeJS themself do also support Blob / File like objects and dosen't need to be strictly the same instances of `globalThis.Blob` so `node-fetch` can now also export the native `FormData` when it's available. 

---

This might be a little bit of topic but i think you should strive towards eventually being able to replace `node-fetch` and `got` with built in features provided by NodeJS themself to have fewer dependencies. a long term goal and a granular replacement would be to: 
- [ ] Switch out `got` for `node-fetch`
- [ ] Switch out `node-fetch` for `Undici` when dropping support for NodeJS v16.8
- [ ] Switch out `Undici` for built in Fetch  when dropping support for NodeJS v18
- [ ] Switch out `fetch-blob/from.js` for  native fn when NodeJS adds a feature to get blob/files backed up by the file system