### PR TITLE
feat(git): added option to use --exclude option on git describe

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -11,6 +11,7 @@
     "commitMessage": "Release ${version}",
     "commitArgs": [],
     "tag": true,
+    "tagExclude": null,
     "tagName": null,
     "tagMatch": null,
     "tagAnnotation": "Release ${version}",

--- a/docs/git.md
+++ b/docs/git.md
@@ -55,12 +55,17 @@ that this represents a glob (not a regex):
 
 Example: `git.tagMatch: "[0-9]*\.[0-9]*\.[0-9]*"`
 
-Or only `"[!-]*"`, as this would match everything that excludes a hyphen, which is normally used excusively in
-pre-releaseses.
-
 This could also be useful when using a plugin to determine the next tag:
 
 Example: `git.tagMatch: "[0-9][0-9].[0-1][0-9].[0-9]*"`
+
+## Tag Exclude
+
+Use `git.tagExclude` to override the normal behavior to find the latest tag. For example whendoing a major release and 
+you want to exclude any sort of pre-releases, use `*[-]*`, as this would exclude everything with a hyphen, which is 
+normally used exclusively in pre-releases.
+
+Example: `git.tagExclude: *[-]*`
 
 ## Extra arguments
 

--- a/docs/pre-releases.md
+++ b/docs/pre-releases.md
@@ -43,13 +43,13 @@ release-it major
 
 <img src="./assets/release-it-prerelease.gif?raw=true" height="524">
 
-When all commits since the latest major tag should be added to the changelog, use `--git.tagMatch`:
+When all commits since the latest major tag should be added to the changelog, use `--git.tagExclude`:
 
 ```bash
-release-it major --git.tagMatch='[0-9]*\\.[0-9]*\\.[0-9]*'
+release-it major --git.tagExclude='*[-]*'
 ```
 
-This will find the latest major matching tag, skipping the pre-release tags.
+This will find the latest major matching tag, excluding the pre-release tags, which normally include `-` in their name. 
 
 Let's go back to when the latest release was `2.0.0-rc.0`. We added new features, which we don't want in the v2 release
 yet, but instead in a later v2.1. A new pre-release id can be made for the minor release after in `2.1.0-alpha.0`:

--- a/lib/plugin/GitBase.js
+++ b/lib/plugin/GitBase.js
@@ -93,7 +93,8 @@ class GitBase extends Plugin {
   getLatestTagName() {
     const context = Object.assign({}, this.config.getContext(), { version: '*' });
     const match = format(this.options.tagMatch || this.options.tagName || '${version}', context);
-    return this.exec(`git describe --tags --match=${match} --abbrev=0`, { options }).then(
+    const exclude = this.options.tagExclude ? `--exclude=${format(this.options.tagExclude, context)}` : '';
+    return this.exec(`git describe --tags --match=${match} --abbrev=0 ${exclude}`, { options }).then(
       stdout => stdout || null,
       () => null
     );

--- a/lib/plugin/GitRelease.js
+++ b/lib/plugin/GitRelease.js
@@ -12,7 +12,7 @@ class GitRelease extends GitBase {
   getInitialOptions(options) {
     const baseOptions = super.getInitialOptions(...arguments);
     const git = options.git || defaultConfig.git;
-    const gitOptions = _.pick(git, ['tagName', 'tagMatch', 'pushRepo', 'changelog']);
+    const gitOptions = _.pick(git, ['tagExclude', 'tagName', 'tagMatch', 'pushRepo', 'changelog']);
     return _.defaults(baseOptions, gitOptions);
   }
 

--- a/test/git.init.js
+++ b/test/git.init.js
@@ -167,6 +167,23 @@ test.serial('should get the latest tag based on tagMatch', async t => {
   t.is(gitClient.config.getContext('latestTag'), '21.04.3');
 });
 
+test.serial('should get the latest tag based on tagExclude', async t => {
+  const shell = factory(Shell);
+  const gitClient = factory(Git, {
+    options: { git: { tagExclude: '*[-]*' } },
+    container: { shell }
+  });
+  sh.exec('git tag 1.0.0');
+  sh.exec('git commit --allow-empty -m "commit 1"');
+  sh.exec('git tag 1.0.1-rc.0');
+  sh.exec('git tag 1.0.1');
+  sh.exec('git commit --allow-empty -m "commit 2"');
+  sh.exec('git tag 1.1.0-rc.0');
+  sh.exec('git push --tags');
+  await gitClient.init();
+  t.is(gitClient.config.getContext('latestTag'), '1.0.1');
+});
+
 test.serial('should generate correct changelog', async t => {
   const gitClient = factory(Git, { options: { git } });
   sh.exec('git tag 1.0.0');


### PR DESCRIPTION
Hello,

There is a small problem in which it isn't possible to exclude certain tags when generating new releases.

For example this image:
![Screen Shot 2022-12-21 at 15 14 16](https://user-images.githubusercontent.com/18369522/208975434-943adfd6-affe-43fe-8601-c7f93c03aa90.png)

Latest commit has tag `15.5.2-rc.0`, previous one has tag `15.5.1`. I ran the `git describe --tags --abbrev=0` as is used in [GitBase](https://github.com/release-it/release-it/compare/master...drmartini7:release-it:master?expand=1#diff-3a1c94688e9b16bb758da2b80710601a1966f46fd660ce47c8512a69e66d8715R97), only changing the match argument:

 - No match, obviously just returns latest tag;
 - `--match='[!-]*'`, as suggested [here](https://github.com/release-it/release-it/compare/master...drmartini7:release-it:master?expand=1#diff-1397ee01a8fd0f298ff6bb0e96747733fde00ced7fd635441e5b562228c62ff1L58), it just returns the latest tag. Why it doesn't work eludes me, as according to [glob(7) documentation](https://man7.org/linux/man-pages/man7/glob.7.html), it should work.
 - `--match='[0-9]*.[0-9]*.[0-9]*'`: this one is suggested [here](https://github.com/release-it/release-it/compare/master...drmartini7:release-it:master?expand=1#diff-fbc0ca3ee709843fbdd268266c349de4f32234fbe35d11084da4c1519c44ec4eL49), but it doesn't work since it uses the `*`, which allows any character, so everything fits.
 - `--exclude='*[-]*'`: this is the way git expects you to exclude a tag from the search as far as I could gather, so my PR aims to include this option on release-it.



There is another problem (which I guess has to do with this PR) that I could see on the tests and documentation, which I guess we could discuss here or I could open an issue to discuss it, but basically, many places on release-it use or suggest a `--match` which is something like `[0-9].[0-9].[0-9]`, like [this test](https://github.com/release-it/release-it/blob/master/test/git.init.js#L197) for example. But this way only works for up to `9.9.9`, never any double digits.

Some places use `*` to allow for more digits, but this has the side effect of allowing commits from pre-releases, which might not be what the user wants, like [here](https://github.com/release-it/release-it/compare/master...drmartini7:release-it:master?expand=1#diff-1397ee01a8fd0f298ff6bb0e96747733fde00ced7fd635441e5b562228c62ff1R56) for example.

Anyway, this isn't strictly to do with my PR, so it can be put aside or discussed on an issue if you wish.

Best Regards.