### PR TITLE
feat: configurable path in git rev-list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.idea
+.vscode
+*.log
+
 node_modules
 package-lock.json
 tmp

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -6,6 +6,7 @@
     "requireBranch": false,
     "requireUpstream": true,
     "requireCommits": false,
+    "commitsPath": "",
     "addUntrackedFiles": false,
     "commit": true,
     "commitMessage": "Release ${version}",

--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -46,7 +46,7 @@ class Git extends GitBase {
     if (this.options.requireUpstream && !(await this.hasUpstreamBranch())) {
       throw e(`No upstream configured for current branch.${EOL}Please set an upstream branch.`, docs);
     }
-    if (this.options.requireCommits && (await this.getCommitsSinceLatestTag()) === 0) {
+    if (this.options.requireCommits && (await this.getCommitsSinceLatestTag(this.options.commitsPath)) === 0) {
       throw e(`There are no commits since the latest tag.`, docs);
     }
   }
@@ -120,10 +120,10 @@ class Git extends GitBase {
     );
   }
 
-  async getCommitsSinceLatestTag() {
+  async getCommitsSinceLatestTag(commitsPath = '') {
     const latestTagName = await this.getLatestTagName();
     const ref = latestTagName ? `${latestTagName}..HEAD` : 'HEAD';
-    return this.exec(`git rev-list ${ref} --count`, { options }).then(Number);
+    return this.exec(`git rev-list ${ref} --count ${commitsPath}`, { options }).then(Number);
   }
 
   async getUpstreamArgs(pushRepo) {

--- a/test/git.init.js
+++ b/test/git.init.js
@@ -72,6 +72,22 @@ test.serial('should not throw if there are commits', async t => {
   await t.notThrowsAsync(gitClient.init());
 });
 
+test.serial('should throw if there are no commits in specified path', async t => {
+  const options = { git: { requireCommits: true, commitsPath: 'dir' } };
+  const gitClient = factory(Git, { options });
+  sh.mkdir('dir');
+  sh.exec('git tag 1.0.0');
+  await t.throwsAsync(gitClient.init(), { message: /^There are no commits since the latest tag/ });
+});
+
+test.serial('should not throw if there are commits in specified path', async t => {
+  const options = { git: { requireCommits: true, commitsPath: 'dir' } };
+  const gitClient = factory(Git, { options });
+  sh.exec('git tag 1.0.0');
+  gitAdd('line', 'dir/file', 'Add file');
+  await t.notThrowsAsync(gitClient.init());
+});
+
 test.serial('should not throw if there are no tags', async t => {
   const options = { git: { requireCommits: true } };
   const gitClient = factory(Git, { options });

--- a/test/util/helpers.js
+++ b/test/util/helpers.js
@@ -10,9 +10,14 @@ const mkTmpDir = () => {
 
 const readFile = file => fs.promises.readFile(path.resolve(file), 'utf8');
 
-const gitAdd = (content, file, message) => {
-  sh.ShellString(content).toEnd(file);
-  sh.exec(`git add ${file}`);
+const gitAdd = (content, filePath, message) => {
+  const pathSegments = filePath.split('/').filter(Boolean);
+  pathSegments.pop();
+  if (pathSegments.length) {
+    sh.mkdir('-p', pathSegments.join('/'));
+  }
+  sh.ShellString(content).toEnd(filePath);
+  sh.exec(`git add ${filePath}`);
   const { stdout } = sh.exec(`git commit -m "${message}"`);
   const match = stdout.match(/\[.+([a-z0-9]{7})\]/);
   return match ? match[1] : null;


### PR DESCRIPTION
Allows providing commits path when `requreCommits: true`.

Makes release-it configuration aligned with `@release-it/conventional-changelog` plugin:

```javascript
const releaseItConfig = {
  plugins: {
    '@release-it/conventional-changelog': {
      preset: 'conventionalcommits',
      path: '.',
      gitRawCommitsOpts: {
        path: '.',
      },
    },
  },
  git: {
    requireCommits: true,
    commitsPath: '.',
    [...]
  },
  [...]
};
```

This configuration is handy when release-it is executed in npm workspace where only related commits should be taken into account.