### PR TITLE
feat: make exit 0 possible when commits required but missing

### DIFF
--- a/bin/release-it.js
+++ b/bin/release-it.js
@@ -3,7 +3,7 @@
 import updater from 'update-notifier';
 import parseArgs from 'yargs-parser';
 import release from '../lib/cli.js';
-import { readJSON, ErrorExitSuccess } from '../lib/util.js';
+import { readJSON } from '../lib/util.js';
 
 const pkg = readJSON(new URL('../package.json', import.meta.url));
 

--- a/bin/release-it.js
+++ b/bin/release-it.js
@@ -3,7 +3,7 @@
 import updater from 'update-notifier';
 import parseArgs from 'yargs-parser';
 import release from '../lib/cli.js';
-import { readJSON } from '../lib/util.js';
+import { readJSON, ErrorExitSuccess } from '../lib/util.js';
 
 const pkg = readJSON(new URL('../package.json', import.meta.url));
 
@@ -38,5 +38,5 @@ const options = parseCliArguments([].slice.call(process.argv, 2));
 updater({ pkg: pkg }).notify();
 release(options).then(
   () => process.exit(0),
-  () => process.exit(1)
+  ({ code }) => process.exit(Number.isInteger(code) ? code : 1)
 );

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -6,6 +6,7 @@
     "requireBranch": false,
     "requireUpstream": true,
     "requireCommits": false,
+    "requireCommitsFail": true,
     "addUntrackedFiles": false,
     "commit": true,
     "commitMessage": "Release ${version}",

--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -47,7 +47,7 @@ class Git extends GitBase {
       throw e(`No upstream configured for current branch.${EOL}Please set an upstream branch.`, docs);
     }
     if (this.options.requireCommits && (await this.getCommitsSinceLatestTag()) === 0) {
-      throw e(`There are no commits since the latest tag.`, docs);
+      throw e(`There are no commits since the latest tag.`, docs, this.options.requireCommitsFail);
     }
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -89,7 +89,11 @@ const parseVersion = raw => {
   };
 };
 
-const e = (message, docs) => new Error(docs ? `${message}${EOL}Documentation: ${docs}${EOL}` : message);
+const e = (message, docs, fail = true) => {
+  const error = new Error(docs ? `${message}${EOL}Documentation: ${docs}${EOL}` : message);
+  error.code = fail ? 1 : 0;
+  return error;
+};
 
 export {
   getSystemInfo,

--- a/test/git.init.js
+++ b/test/git.init.js
@@ -72,6 +72,20 @@ test.serial('should not throw if there are commits', async t => {
   await t.notThrowsAsync(gitClient.init());
 });
 
+test.serial('should fail (exit code 1) if there are no commits', async t => {
+  const options = { git: { requireCommits: true } };
+  const gitClient = factory(Git, { options });
+  sh.exec('git tag 1.0.0');
+  await t.throwsAsync(gitClient.init(), { code: 1 });
+});
+
+test.serial('should not fail (exit code 0) if there are no commits', async t => {
+  const options = { git: { requireCommits: true, requireCommitsFail: false } };
+  const gitClient = factory(Git, { options });
+  sh.exec('git tag 1.0.0');
+  await t.throwsAsync(gitClient.init(), { code: 0 });
+});
+
 test.serial('should not throw if there are no tags', async t => {
   const options = { git: { requireCommits: true } };
   const gitClient = factory(Git, { options });


### PR DESCRIPTION
This PR introduces a possibility to exit with 0 code (success) when `requireCommits: true` and no commits available.

Why this is handy:

Alongside with this PR https://github.com/release-it/release-it/pull/982 it will make release-it a monorepo best friend.

Some times it is OK not to have commits related to a certain workspace. Exit with error may stop the pipeline execution, depending on CI configuration.

This particular feature is inspired by monorepo managed by turborepo where every workspace has a `"release": "release-it"` npm script in `package.json`.

When turbo release pipeline is executed failing releases are:
- terminating pipeline execution
- preventing execution results to be cached

I my case, right now, a custom script, which checks if there commits that touch a specific workspace, prevents an execution of release-it (not to exit with non zero code).

Its kinda specific use case but I think it can be a great addition to release-it.