### PR TITLE
Update docs with the new workspaces plugin name

### DIFF
--- a/docs/npm.md
+++ b/docs/npm.md
@@ -134,7 +134,7 @@ Monorepos do not require extra configuration, but release-it handles only one pa
 To bump multiple `package.json` files in a monorepo to the same version, use the
 [@release-it/bumper](https://github.com/release-it/bumper) plugin.
 
-For Yarn workspaces, see the [release-it-yarn-workspaces](https://github.com/rwjblue/release-it-yarn-workspaces) plugin.
+For Yarn workspaces, see the [@release-it-plugins/workspaces](https://github.com/release-it-plugins/workspaces).
 
 ## Miscellaneous
 


### PR DESCRIPTION
[release-it-yarn-workspaces](https://www.npmjs.com/package/release-it-yarn-workspaces) is now deprecated and moved under `@release-it-plugins`.

This PR updates the `npm.md` docs with the change.

Let me know if anything should be changed.

