### PR TITLE
Skip version release if plugin `getIncrementedVersion` return null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,14 +77,15 @@ const runTasks = async (opts, di) => {
     const action = config.isIncrement ? 'release' : 'update';
     const suffix = version && config.isIncrement ? `${latestVersion}...${version}` : `currently at ${latestVersion}`;
 
-    if (!config.isReleaseVersion && !config.isChangelog) {
-      log.obtrusive(`🚀 Let's ${action} ${name} (${suffix})`);
-
-      log.preview({ title: 'changelog', text: changelog });
-    }
-
     if (config.isIncrement) {
       version = version || (await reduceUntil(plugins, plugin => plugin.getIncrementedVersion(incrementBase)));
+    }
+
+    if (!version) {
+      log.obtrusive(`No new version to release`);
+    } else if (!config.isReleaseVersion && !config.isChangelog) {
+      log.obtrusive(`🚀 Let's ${action} ${name} (${suffix})`);
+      log.preview({ title: 'changelog', text: changelog });
     }
 
     if (config.isReleaseVersion) {


### PR DESCRIPTION
Hi! 
Love this package, using it in our CI infrastructure!

Added a small change to support case when plugin returns null in `getIncrementedVersion` (this is possible, [example one](https://github.com/release-it/conventional-changelog/blob/master/index.js#L58), [example two](https://github.com/release-it/conventional-changelog/blob/master/index.js#LL139C48-L139C69))