### PR TITLE
fix: unable to open the browser automatically on Windows system

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -338,7 +338,8 @@ class GitHub extends Release {
       this.setContext({ isReleased: true, releaseUrl: url });
     } else {
       this.log.log(`\n💡 If your browser does not automatically open the GitHub Release web interface, please manually copy the link and paste it into your browser to proceed: ${url}\n`);
-      await open(url, { wait: true });
+      const runningOnWindows = process.platform === 'win32';
+      await open(url, { wait: runningOnWindows });
       this.setContext({ isReleased: true, releaseUrl: this.getReleaseUrlFallback(tagName) });
     }
   }

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -337,7 +337,8 @@ class GitHub extends Release {
     if (isCI) {
       this.setContext({ isReleased: true, releaseUrl: url });
     } else {
-      await open(url);
+      this.log.log(`\n💡 If your browser does not automatically open the GitHub Release web interface, please manually copy the link and paste it into your browser to proceed: ${url}\n`);
+      await open(url, { wait: true });
       this.setContext({ isReleased: true, releaseUrl: this.getReleaseUrlFallback(tagName) });
     }
   }


### PR DESCRIPTION
Using `await open(url, { wait: true })` can solve the issue of the browser not automatically opening on Windows devices. Additionally, a prompt has been added to the terminal to display the GitHub Release web interface URL, allowing users to manually copy and paste it into the browser for further operation if the browser does not open automatically.