### PR TITLE
fix: name of param to enable comment functionality

### DIFF
--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -168,7 +168,7 @@ release-it --no-increment --no-git --github.release --github.update --github.ass
 
 ## Comments
 
-To submit a comment to each merged pull requests and closed issue that is part of the release, set `github.comments` to
+To submit a comment to each merged pull requests and closed issue that is part of the release, set `github.comments.submit` to
 `true`. Here are the default settings:
 
 ```json


### PR DESCRIPTION
Given this code:
https://github.com/release-it/release-it/blob/38193c37f6e570907eb8c7df02a9a41714eba509/lib/plugin/github/GitHub.js#L375C1-L379C51

I think that the parameter to set has to be `github.comments.submit` instead of `github.comments`