### PR TITLE
Parse issues from commit log instead of changelog

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -376,7 +376,7 @@ class GitHub extends Release {
     const { submit, issue, pr } = comments;
     const context = this.getContext();
 
-    if (!submit || !changelog || isDryRun) return;
+    if (!submit || !changelog) return;
 
     const shas = getCommitsFromChangelog(changelog);
     const searchResults = await Promise.all(searchQueries(this.client, owner, repo, shas));
@@ -390,6 +390,11 @@ class GitHub extends Release {
       const comment = format(format(type === 'pr' ? pr : issue, context), context);
       const url = `${host}/${owner}/${repo}/${type === 'pr' ? 'pull' : 'issues'}/${number}`;
 
+      if (isDryRun) {
+        this.log.exec(`octokit issues.createComment (${url})`, { isDryRun });
+        return;
+      }
+      
       try {
         await this.client.issues.createComment({ owner, repo, issue_number: number, body: comment });
         this.log.log(`● Commented on ${url}`);

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -371,7 +371,7 @@ class GitHub extends Release {
   async commentOnResolvedItems() {
     const { isDryRun } = this.config;
     const { owner, project: repo } = this.getContext('repo');
-    const { changelog } = this.config.getContext();
+    const changelog = await this.getChangelog();
     const { comments } = this.options;
     const { submit, issue, pr } = comments;
     const context = this.getContext();


### PR DESCRIPTION
fix: #1070

```bash
northword@Yoga-Northword MINGW64 /d/Code/Zotero/zotero-format-metadata (main)
$ pnpm release --github.release --dry-run --VV --no-git.requireCleanWorkingDir

> zotero-format-metadata@1.6.17 release D:\Code\Zotero\zotero-format-metadata
> release-it "--github.release" "--dry-run" "--VV" "--no-git.requireCleanWorkingDir"

$ git rev-parse --abbrev-ref HEAD
$ git config --get branch.main.remote
$ git remote get-url origin
! git fetch
$ git rev-parse --abbrev-ref HEAD  [cached]
$ git describe --tags --match=v* --abbrev=0
$ git symbolic-ref HEAD
$ git for-each-ref --format="%(upstream:short)" refs/heads/main
$ git rev-parse --abbrev-ref HEAD  [cached]
$ git config --get branch.main.remote  [cached]
$ git remote get-url origin  [cached]
! git fetch
$ git rev-parse --abbrev-ref HEAD  [cached]
$ git describe --tags --match=v* --abbrev=0  [cached]

🚀 Let's release zotero-format-metadata (currently at 1.6.17)


Changelog:
管道测试。[#103](https://github.com/northword/zotero-format-metadata/issues/103)

? Select increment (next version): patch (1.6.18)
! npm version 1.6.18 --no-git-tag-version
! npm run build
$ git status --short --untracked-files=no

Empty changeset

! git add . --update
? Commit (chore(publish): release v1.6.18)? Yes
! git commit --message chore(publish): release v1.6.18
? Tag (v1.6.18)? Yes
! git tag --annotate --message Release 1.6.18 v1.6.18
? Push? Yes
$ git symbolic-ref HEAD  [cached]
$ git for-each-ref --format="%(upstream:short)" refs/heads/main  [cached]
! git push --follow-tags
? Create a release on GitHub (Release 1.6.18)? Yes
! octokit repos.createRelease "Release 1.6.18" (v1.6.18)
! octokit repos.uploadReleaseAssets build/*.xpi update.json
$ git log --pretty=format:"* %s (%h)" v1.6.17...HEAD
! octokit issues.createComment (https://github.com/northword/zotero-format-metadata/issues/103)   # Changes Here!
! echo Successfully released zotero-format-metadata v1.6.18 to northword/zotero-format-metadata.
🔗 https://github.com/northword/zotero-format-metadata/releases/tag/v1.6.18
🏁 Done (in 5s.)
```