### PR TITLE
Add comment on PRs in CI environments

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -127,7 +127,6 @@ class GitHub extends Release {
   }
 
   async release() {
-    const { assets } = this.options;
     const { isWeb, isUpdate } = this.getContext();
     const { isCI } = this.config;
 
@@ -140,7 +139,10 @@ class GitHub extends Release {
     } else if (isCI) {
       await this.step({ task: () => this[publishMethod](), label: `GitHub ${type} release` });
       await this.step({ task: () => this.uploadAssets(), label: 'GitHub upload assets' });
-      return this.step({ task: () => isUpdate ? Promise.resolve() : this.commentOnResolvedItems(), label: 'GitHub comment on resolved items' });
+      return this.step({
+        task: () => (isUpdate ? Promise.resolve() : this.commentOnResolvedItems()),
+        label: 'GitHub comment on resolved items'
+      });
     } else {
       const release = async () => {
         await this[publishMethod]();
@@ -374,7 +376,7 @@ class GitHub extends Release {
     const { owner, project: repo } = this.getContext('repo');
     const changelog = await this.getChangelog();
     const { comments } = this.options;
-    const { submit, issue, pr } = comments;
+    const { submit, issue, pr } = comments ?? {};
     const context = this.getContext();
 
     if (!submit || !changelog) return;

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -139,7 +139,8 @@ class GitHub extends Release {
       return this.step({ task, label: 'Generating link to GitHub Release web interface', prompt: 'release' });
     } else if (isCI) {
       await this.step({ task: () => this[publishMethod](), label: `GitHub ${type} release` });
-      return this.step({ enabled: assets, task: () => this.uploadAssets(), label: 'GitHub upload assets' });
+      await this.step({ task: () => this.uploadAssets(), label: 'GitHub upload assets' });
+      return this.step({ task: () => isUpdate ? Promise.resolve() : this.commentOnResolvedItems(), label: 'GitHub comment on resolved items' });
     } else {
       const release = async () => {
         await this[publishMethod]();


### PR DESCRIPTION
closes #1057 

As described in the issue #1057 the comments aren't added in CI environment.
Here is a simple fix for it.

I was trying to understand why they weren't enabled but actually I do not see any reason.