### PR TITLE
Catch and log errors thrown in `rollbackTagPush()` in Git plugin

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -215,7 +215,12 @@ class Git extends GitBase {
       this.disableRollback();
       return push;
     } catch (error) {
-      await this.rollbackTagPush();
+      try {
+        await this.rollbackTagPush();
+      } catch (tagError) {
+        this.log.warn(`An error was encountered when trying to rollback the tag on the remote: ${tagError.message}`);
+      }
+      
       throw error;
     }
   }


### PR DESCRIPTION
Fixes #1086 