### PR TITLE
Exit without error message when requireCommits is true but requireCommitsFail is false and no commits are available

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -1,4 +1,5 @@
 import { EOL } from 'node:os';
+import { exit } from 'node:process';
 import _ from 'lodash';
 import { execa } from 'execa';
 import matcher from 'wildcard-match';
@@ -47,7 +48,14 @@ class Git extends GitBase {
       throw e(`No upstream configured for current branch.${EOL}Please set an upstream branch.`, docs);
     }
     if (this.options.requireCommits && (await this.getCommitsSinceLatestTag(this.options.commitsPath)) === 0) {
-      throw e(`There are no commits since the latest tag.`, docs, this.options.requireCommitsFail);
+      const requireCommitsFailMessage = 'There are no commits since the latest tag.';
+
+      if (this.options.requireCommitsFail) {
+        throw e(requireCommitsFailMessage, docs, this.options.requireCommitsFail);
+      }
+
+      this.log.info(`${requireCommitsFailMessage}${EOL}Documentation: ${docs}${EOL}`);
+      exit(0);
     }
   }
 

--- a/test/git.init.js
+++ b/test/git.init.js
@@ -1,3 +1,4 @@
+import { EOL } from 'node:os';
 import test from 'ava';
 import sh from 'shelljs';
 import Shell from '../lib/shell.js';
@@ -65,7 +66,7 @@ test.serial('should throw if no upstream is configured', async t => {
 });
 
 test.serial('should throw if there are no commits', async t => {
-  const options = { git: { requireCommits: true } };
+  const options = { git: { requireCommits: true, requireCommitsFail: true } };
   const gitClient = factory(Git, { options });
   sh.exec('git tag 1.0.0');
   await t.throwsAsync(gitClient.init(), { message: /^There are no commits since the latest tag/ });
@@ -80,7 +81,7 @@ test.serial('should not throw if there are commits', async t => {
 });
 
 test.serial('should fail (exit code 1) if there are no commits', async t => {
-  const options = { git: { requireCommits: true } };
+  const options = { git: { requireCommits: true, requireCommitsFail: true } };
   const gitClient = factory(Git, { options });
   sh.exec('git tag 1.0.0');
   await t.throwsAsync(gitClient.init(), { code: 1 });
@@ -94,7 +95,7 @@ test.serial('should not fail (exit code 0) if there are no commits', async t => 
 });
 
 test.serial('should throw if there are no commits in specified path', async t => {
-  const options = { git: { requireCommits: true, commitsPath: 'dir' } };
+  const options = { git: { requireCommits: true, requireCommitsFail: true, commitsPath: 'dir' } };
   const gitClient = factory(Git, { options });
   sh.mkdir('dir');
   sh.exec('git tag 1.0.0');


### PR DESCRIPTION
## Change

Updating the flow to when `requireCommits` is true but `requireCommitsFail` is set as false and no commits are available, instead of returning `ERROR There are no commits since the latest tag.` just returns `There are no commits since the latest tag.` and remove the `ERROR` string to as that is misleading.

Fixes #1095