### PR TITLE
Exit without error message when requireCommits is true but requireCommitsFail is false and no commits are available 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,12 @@ const runTasks = async (opts, di) => {
     };
   } catch (err) {
     const { log } = container;
-    log ? log.error(err.message || err) : console.error(err); // eslint-disable-line no-console
+
+    const errorMessage = err.message || err;
+    const logger = log || console;
+
+    err.name === 'INFO' ? logger.info(errorMessage) : logger.error(errorMessage); // eslint-disable-line no-console
+
     throw err;
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,7 +142,7 @@ const runTasks = async (opts, di) => {
     const errorMessage = err.message || err;
     const logger = log || console;
 
-    err.name === 'INFO' ? logger.info(errorMessage) : logger.error(errorMessage); // eslint-disable-line no-console
+    err.cause === 'INFO' ? logger.info(errorMessage) : logger.error(errorMessage);
 
     throw err;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -92,7 +92,7 @@ const parseVersion = raw => {
 const e = (message, docs, fail = true) => {
   const error = new Error(docs ? `${message}${EOL}Documentation: ${docs}${EOL}` : message);
   error.code = fail ? 1 : 0;
-  error.name = fail ? error.name : 'INFO';
+  error.cause = fail ? 'ERROR' : 'INFO';
   return error;
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -92,6 +92,7 @@ const parseVersion = raw => {
 const e = (message, docs, fail = true) => {
   const error = new Error(docs ? `${message}${EOL}Documentation: ${docs}${EOL}` : message);
   error.code = fail ? 1 : 0;
+  error.name = fail ? error.name : 'INFO';
   return error;
 };
 

--- a/test/git.init.js
+++ b/test/git.init.js
@@ -76,7 +76,7 @@ test.serial('should not throw if there are commits', async t => {
   const gitClient = factory(Git, { options });
   sh.exec('git tag 1.0.0');
   gitAdd('line', 'file', 'Add file');
-  await t.notThrowsAsync(gitClient.init());
+  await t.notThrowsAsync(gitClient.init(), 'There are no commits since the latest tag');
 });
 
 test.serial('should fail (exit code 1) if there are no commits', async t => {


### PR DESCRIPTION
### Change

Updating the flow to when requireCommits is true but requireCommitsFail is set as false and no commits are available, instead of returning ERROR There are no commits since the latest tag. just returns There are no commits since the latest tag. and remove the ERROR string as that is misleading.

Fixes https://github.com/release-it/release-it/issues/1095

