### PR TITLE
fix: ship & export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
   },
   "type": "module",
   "exports": {
-    ".": "./lib/index.js",
+    ".":{
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "types": "./types/index.d.ts"
+    },
     "./package.json": "./package.json",
     "./test/util/index.js": "./test/util/index.js"
   },
@@ -56,7 +60,8 @@
     "config",
     "lib",
     "test",
-    "schema"
+    "schema",
+    "types"
   ],
   "types": "./types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
- Add `types` folder to `files` in `package.json`, so they are effectively shipped in npm package
- Correctly export them through `exports` in `package.json`

# Before 

![image](https://github.com/release-it/release-it/assets/25272043/fe8e1239-a06f-43c7-9ed4-cab3b428b84d)

# After

![image](https://github.com/release-it/release-it/assets/25272043/107e1e7f-bb59-4ed7-b3be-109b3857af17)
