### PR TITLE
fix(types): requireBranch is either a string, false, or undefined

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -13,7 +13,7 @@ export interface Config {
     requireCleanWorkingDir?: boolean;
 
     /** @default false */
-    requireBranch?: boolean;
+    requireBranch?: false | string;
 
     /** @default true */
     requireUpstream?: boolean;


### PR DESCRIPTION
Hit a type error when using `requireBranch`. The correct type seems to be a `string`, `undefined`, or `false`, which is apparently the default.