### PR TITLE
feat: add secure flag to gitlab config

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -63,6 +63,7 @@
     "tokenRef": "GITLAB_TOKEN",
     "tokenHeader": "Private-Token",
     "certificateAuthorityFile": null,
+    "secure": null,
     "assets": null,
     "origin": null,
     "skipChecks": false

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -109,6 +109,23 @@ specify the root CA certificate with `certificateAuthorityFile`, for example:
 }
 ```
 
+Alternatively, if you want to disable the server certificate verication against the list of supplied CAs, you can set
+the `secure` flag to false:
+
+```json
+{
+  "gitlab": {
+    "release": true,
+    "tokenHeader": "PRIVATE-TOKEN",
+    "secure": false
+  }
+}
+```
+
+The `secure` option is passed down to [got](https://github.com/sindresorhus/got), which in turn also forwards it to node's
+[`https.request`](https://nodejs.org/api/https.html#httpsrequestoptions-callback) method as the `rejectUnauthorized` option.
+The default value of `rejectUnauthorized` is `true`.
+
 ## Update the latest release
 
 The latest GitLab release can be updated, e.g. to update the releases notes or add release assets.

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -109,7 +109,7 @@ specify the root CA certificate with `certificateAuthorityFile`, for example:
 }
 ```
 
-Alternatively, if you want to disable the server certificate verication against the list of supplied CAs, you can set
+Alternatively, if you want to disable the server certificate verification against the list of supplied CAs, you can set
 the `secure` flag to false:
 
 ```json

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -23,7 +23,9 @@ class GitLab extends Release {
       certificateAuthority: certificateAuthorityFile ? fs.readFileSync(certificateAuthorityFile) : undefined,
       rejectUnauthorized: typeof secure === 'boolean' ? secure : undefined
     };
-    const https = _.merge({}, httpsOptions);
+
+    // Remove keys with undefined values
+    const https = _.pickBy(httpsOptions, value => value !== undefined);
 
     this.certificateAuthorityOption = _.isEmpty(https) ? {} : { https };
   }

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -17,10 +17,15 @@ class GitLab extends Release {
     super(...args);
     this.registerPrompts(prompts);
     this.assets = [];
-    const { certificateAuthorityFile } = this.options;
-    this.certificateAuthorityOption = certificateAuthorityFile
-      ? { https: { certificateAuthority: fs.readFileSync(certificateAuthorityFile) } }
-      : {};
+    const { certificateAuthorityFile, secure } = this.options;
+
+    const httpsOptions = {
+      certificateAuthority: certificateAuthorityFile ? fs.readFileSync(certificateAuthorityFile) : undefined,
+      rejectUnauthorized: typeof secure === 'boolean' ? secure : undefined
+    };
+    const https = _.merge({}, httpsOptions);
+
+    this.certificateAuthorityOption = _.isEmpty(https) ? {} : { https };
   }
 
   get client() {

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -46,6 +46,9 @@
     "certificateAuthorityFile": {
       "default": null
     },
+    "secure": {
+      "default": null
+    },
     "assets": {
       "default": null
     },

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -256,27 +256,45 @@ test('should handle certificate authority options', t => {
   const sandbox = sinon.createSandbox();
   sandbox.stub(fs, 'readFileSync').returns('test certificate');
 
-  let gitlab = factory(GitLab, { options: { gitlab: {} } });
-  t.deepEqual(gitlab.certificateAuthorityOption, {});
+  {
+    const options = { gitlab: {} };
+    const gitlab = factory(GitLab, { options });
+    t.deepEqual(gitlab.certificateAuthorityOption, {});
+  }
 
-  gitlab = factory(GitLab, { options: { gitlab: { certificateAuthorityFile: 'cert.crt' } } });
-  t.deepEqual(gitlab.certificateAuthorityOption, { https: { certificateAuthority: 'test certificate' } });
+  {
+    const options = { gitlab: { certificateAuthorityFile: 'cert.crt' } };
+    const gitlab = factory(GitLab, { options });
+    t.deepEqual(gitlab.certificateAuthorityOption, { https: { certificateAuthority: 'test certificate' } });
+  }
 
-  gitlab = factory(GitLab, { options: { gitlab: { secure: false } } });
-  t.deepEqual(gitlab.certificateAuthorityOption, { https: { rejectUnauthorized: false } });
+  {
+    const options = { gitlab: { secure: false } };
+    const gitlab = factory(GitLab, { options });
+    t.deepEqual(gitlab.certificateAuthorityOption, { https: { rejectUnauthorized: false } });
+  }
 
-  gitlab = factory(GitLab, { options: { gitlab: { secure: true } } });
-  t.deepEqual(gitlab.certificateAuthorityOption, { https: { rejectUnauthorized: true } });
+  {
+    const options = { gitlab: { secure: true } };
+    const gitlab = factory(GitLab, { options });
+    t.deepEqual(gitlab.certificateAuthorityOption, { https: { rejectUnauthorized: true } });
+  }
 
-  gitlab = factory(GitLab, { options: { gitlab: { certificateAuthorityFile: 'cert.crt', secure: true } } });
-  t.deepEqual(gitlab.certificateAuthorityOption, {
-    https: { certificateAuthority: 'test certificate', rejectUnauthorized: true }
-  });
+  {
+    const options = { gitlab: { certificateAuthorityFile: 'cert.crt', secure: true } };
+    const gitlab = factory(GitLab, { options });
+    t.deepEqual(gitlab.certificateAuthorityOption, {
+      https: { certificateAuthority: 'test certificate', rejectUnauthorized: true }
+    });
+  }
 
-  gitlab = factory(GitLab, { options: { gitlab: { certificateAuthorityFile: 'cert.crt', secure: false } } });
-  t.deepEqual(gitlab.certificateAuthorityOption, {
-    https: { certificateAuthority: 'test certificate', rejectUnauthorized: false }
-  });
+  {
+    const options = { gitlab: { certificateAuthorityFile: 'cert.crt', secure: false } };
+    const gitlab = factory(GitLab, { options });
+    t.deepEqual(gitlab.certificateAuthorityOption, {
+      https: { certificateAuthority: 'test certificate', rejectUnauthorized: false }
+    });
+  }
 
   sandbox.restore();
 });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -170,6 +170,9 @@ export interface Config {
 
     /** @default null */
     certificateAuthorityFile?: any;
+    
+    /** @default null */
+    secure?: boolean;
 
     /** @default null */
     assets?: any;


### PR DESCRIPTION
This PR adds a new flag to the gitlab config options: `secure`.

If the value of this flag is **not** `undefined`, it will be forward to https request library (`got`), which in turn also forwards it to node's `https.request` method as the `rejectUnauthorized` flag.

The `rejectUnauthorized` flag is `true` by default. When its value is `false`, it allows node to make https requests to servers without verifying the server certificate against the list of trusted CA's.

The goal of this PR is to reduce the effort to create gitlab releases for teams working with self-hosted private gitlab instances, skipping the need of having to pass CA certificates around.

Fix: #1125 



