### PR TITLE
feat(github): expose github make_latest flag

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./schema/release-it.json",
   "hooks": {
     "after:init": ["npm run lint", "npm run knip", "npm test"]
   },

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -166,6 +166,11 @@ Example command to add assets and explicitly toggle the draft status to "publish
 release-it --no-increment --no-git --github.release --github.update --github.assets=*.zip --no-github.draft
 ```
 
+## Project Non-Latest Release
+
+To do a release that isn't the latest release on your GitHub project e.g for support releases, you can set
+`github.makeLatest` to `false`.
+
 ## Comments
 
 To submit a comment to each merged pull requests and closed issue that is part of the release, set

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -13,6 +13,10 @@ import Release from '../GitRelease.js';
 import prompts from './prompts.js';
 import { getCommitsFromChangelog, getResolvedIssuesFromChangelog, searchQueries } from './util.js';
 
+/**
+ * @typedef {import('@octokit/rest').RestEndpointMethodTypes['repos']['createRelease']['parameters']} CreateReleaseOptions
+ */
+
 const pkg = readJSON(new URL('../../../package.json', import.meta.url));
 
 const docs = 'https://git.io/release-it-github';
@@ -205,15 +209,19 @@ class GitHub extends Release {
 
   getOctokitReleaseOptions(options = {}) {
     const { owner, project: repo } = this.getContext('repo');
-    const { releaseName, draft = false, preRelease = false, autoGenerate = false } = this.options;
+    const { releaseName, draft = false, preRelease = false, autoGenerate = false, makeLatest = true } = this.options;
     const { tagName } = this.config.getContext();
     const { version, releaseNotes, isUpdate } = this.getContext();
     const { isPreRelease } = parseVersion(version);
     const name = format(releaseName, this.config.getContext());
     const body = autoGenerate ? (isUpdate ? null : '') : truncateBody(releaseNotes);
 
-    return Object.assign(options, {
+    /**
+     * @type {CreateReleaseOptions}
+     */
+    const contextOptions = {
       owner,
+      make_latest: makeLatest.toString(),
       repo,
       tag_name: tagName,
       name,
@@ -221,7 +229,8 @@ class GitHub extends Release {
       draft,
       prerelease: isPreRelease || preRelease,
       generate_release_notes: autoGenerate
-    });
+    };
+    return Object.assign(options, contextOptions);
   }
 
   retry(fn) {

--- a/schema/github.json
+++ b/schema/github.json
@@ -20,6 +20,10 @@
       "type": "boolean",
       "default": false
     },
+    "makeLatest": {
+      "anyOf": [{ "type": "boolean" }, { "const": "legacy" }],
+      "default": true
+    },
     "preRelease": {
       "type": "boolean",
       "default": false

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -53,7 +53,8 @@ const interceptCreate = ({
       body,
       prerelease,
       draft,
-      generate_release_notes
+      generate_release_notes,
+      make_latest: 'true'
     })
     .reply(() => {
       const id = 1;
@@ -80,7 +81,15 @@ const interceptUpdate = ({
   body: { tag_name, name = '', body = null, prerelease = false, draft = false, generate_release_notes = false }
 } = {}) => {
   nock(api)
-    .patch(`/repos/${owner}/${project}/releases/1`, { tag_name, name, body, draft, prerelease, generate_release_notes })
+    .patch(`/repos/${owner}/${project}/releases/1`, {
+      tag_name,
+      name,
+      body,
+      draft,
+      prerelease,
+      generate_release_notes,
+      make_latest: 'true'
+    })
     .reply(200, {
       id: 1,
       tag_name,

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -132,6 +132,13 @@ export interface Config {
     /** @default null */
     proxy?: any;
 
+    /**
+     * @default true
+     * 'legacy' - Github determines the latest release based on the release creation date and higher semantic version.
+     * See https://docs.github.com/en/rest/releases/releases?apiVersion=latest#create-a-release
+     */
+    makeLatest?: boolean | 'legacy';
+
     /** @default false */
     skipChecks?: boolean;
 
@@ -170,7 +177,7 @@ export interface Config {
 
     /** @default null */
     certificateAuthorityFile?: any;
-    
+
     /** @default null */
     secure?: boolean;
 


### PR DESCRIPTION
In a project we create non-latest support release regularly. It is annoying to reset the latest release everytime.
Unfortunately release-it does not expose the make_latest flag from  the [GitHub API](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release).

This PR exposes this option.

Something to think about: Should the `make_latest: "legacy"` option even be exposed or should it be renamed?

I tested this here: https://github.com/sirchnik/test-npm