### PR TITLE
Fix uploaded assets URL for Gitlab version >= 17.2

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -65,6 +65,7 @@
     "certificateAuthorityFile": null,
     "secure": null,
     "assets": null,
+    "useIdsForUrls": false,
     "origin": null,
     "skipChecks": false
   }

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -89,6 +89,19 @@ download from the project's releases page. Example:
 }
 ```
 
+Version 17.2 of Gitlab [started enforcing a new URL format](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/156939)
+for uploaded assets. If you are using this version (or later), you should set the `useIdsForUrls` flag to `true`:
+
+```json
+{
+  "gitlab": {
+    "release": true,
+    "useIdsForUrls": true,
+    "assets": ["dist/*.dmg"]
+  }
+}
+```
+
 ## Origin
 
 The `origin` can be set to a string such as `"http://example.org:3000"` to use a different origin from what would be

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -237,6 +237,7 @@ class GitLab extends Release {
 
   async uploadAsset(filePath) {
     const name = path.basename(filePath);
+    const { useIdsForUrls } = this.options;
     const { id, origin, repo } = this.getContext();
     const endpoint = `projects/${id}/uploads`;
 
@@ -250,7 +251,7 @@ class GitLab extends Release {
       this.log.verbose(`gitlab releases#uploadAsset: done (${body.url})`);
       this.assets.push({
         name,
-        url: `${origin}/${repo.repository}${body.url}`
+        url: useIdsForUrls ? `${origin}${body.full_path}` : `${origin}/${repo.repository}${body.url}`
       });
     } catch (err) {
       this.debug(err);

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -28,7 +28,7 @@
       "type": "boolean",
       "default": false
     },
-    "milesstones": {
+    "milestones": {
       "type": "array",
       "items": {
         "type": "string"

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -52,6 +52,10 @@
     "assets": {
       "default": null
     },
+    "useIdsForUrls": {
+      "type": "boolean",
+      "default": false
+    },
     "origin": {
       "type": "string",
       "default": null

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -111,6 +111,31 @@ test.serial('should upload assets and release', async t => {
   t.is(releaseUrl, `${pushRepo}/-/releases`);
 });
 
+test.serial('should upload assets with ID-based URLs too', async t => {
+  const host = 'https://gitlab.com'
+  const pushRepo = `${host}/user/repo`;
+  const options = {
+    git: { pushRepo },
+    gitlab: {
+      tokenRef,
+      release: true,
+      assets: 'test/resources/file-v${version}.txt',
+      useIdsForUrls: true,
+    }
+  };
+  const gitlab = factory(GitLab, { options });
+  sinon.stub(gitlab, 'getLatestVersion').resolves('2.0.0');
+
+  interceptUser();
+  interceptCollaborator();
+  interceptAsset();
+  interceptPublish();
+
+  await runTasks(gitlab);
+
+  t.is(gitlab.assets[0].url, `${host}/-/project/1234/uploads/7e8bec1fe27cc46a4bc6a91b9e82a07c/file-v2.0.1.txt`);
+});
+
 test.serial('should throw when release milestone is missing', async t => {
   const pushRepo = 'https://gitlab.com/user/repo';
   const options = {

--- a/test/stub/gitlab.js
+++ b/test/stub/gitlab.js
@@ -39,6 +39,7 @@ export let interceptAsset = ({ host = 'https://gitlab.com', owner = 'user', proj
       return {
         alt: name,
         url: `/uploads/7e8bec1fe27cc46a4bc6a91b9e82a07c/${name}`,
+        full_path: `/-/project/1234/uploads/7e8bec1fe27cc46a4bc6a91b9e82a07c/${name}`,
         markdown: `[${name}](/uploads/7e8bec1fe27cc46a4bc6a91b9e82a07c/${name})`
       };
     });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -184,6 +184,9 @@ export interface Config {
     /** @default null */
     assets?: any;
 
+    /** @default false */
+    useIdsForUrls?: boolean;
+
     /** @default null */
     origin?: any;
 


### PR DESCRIPTION
Gitlab started to use a [new URL format](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/150939) for uploaded assets in version 17.1 and since version 17.2 all new uploaded assets are [no longer accessible via the old URL format](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/156939), which means that uploaded assets are no longer accessible from the links in the release.

This PR introduces a new flag for Gitlab which allows the user to choose which URL format release-it should use when publishing the uploaded assets in a new release.