### PR TITLE
feat(github): added support to create github discussion on release creation

### DIFF
--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -177,8 +177,6 @@ To auto-create GitHub Discussion for the release on your GitHub project, you can
 
 `github.discussionCategoryName` to `[discussion category name]`
 
-Default value is set as `false`, which will not create any discussion.
-
 ## Comments
 
 To submit a comment to each merged pull requests and closed issue that is part of the release, set

--- a/docs/github-releases.md
+++ b/docs/github-releases.md
@@ -171,6 +171,14 @@ release-it --no-increment --no-git --github.release --github.update --github.ass
 To do a release that isn't the latest release on your GitHub project e.g for support releases, you can set
 `github.makeLatest` to `false`.
 
+## Create GitHub Discussion
+
+To auto-create GitHub Discussion for the release on your GitHub project, you can set:
+
+`github.discussionCategoryName` to `[discussion category name]`
+
+Default value is set as `false`, which will not create any discussion.
+
 ## Comments
 
 To submit a comment to each merged pull requests and closed issue that is part of the release, set

--- a/lib/plugin/GitRelease.js
+++ b/lib/plugin/GitRelease.js
@@ -48,9 +48,12 @@ class GitRelease extends GitBase {
   }
 
   afterRelease() {
-    const { isReleased, releaseUrl } = this.getContext();
+    const { isReleased, releaseUrl, discussionUrl } = this.getContext();
     if (isReleased) {
       this.log.log(`🔗 ${releaseUrl}`);
+    }
+    if (discussionUrl) {
+      this.log.log(`🔗 ${discussionUrl}`);
     }
   }
 }

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -209,7 +209,14 @@ class GitHub extends Release {
 
   getOctokitReleaseOptions(options = {}) {
     const { owner, project: repo } = this.getContext('repo');
-    const { releaseName, draft = false, preRelease = false, autoGenerate = false, makeLatest = true } = this.options;
+    const {
+      releaseName,
+      draft = false,
+      preRelease = false,
+      autoGenerate = false,
+      makeLatest = true,
+      discussionCategoryName = false
+    } = this.options;
     const { tagName } = this.config.getContext();
     const { version, releaseNotes, isUpdate } = this.getContext();
     const { isPreRelease } = parseVersion(version);
@@ -228,7 +235,8 @@ class GitHub extends Release {
       body,
       draft,
       prerelease: isPreRelease || preRelease,
-      generate_release_notes: autoGenerate
+      generate_release_notes: autoGenerate,
+      discussion_category_name: discussionCategoryName
     };
     return Object.assign(options, contextOptions);
   }

--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -265,9 +265,21 @@ class GitHub extends Release {
         this.debug(options);
         const response = await this.client.repos.createRelease(options);
         this.debug(response.data);
-        const { html_url, upload_url, id } = response.data;
-        this.setContext({ isReleased: true, releaseId: id, releaseUrl: html_url, upload_url });
-        this.config.setContext({ isReleased: true, releaseId: id, releaseUrl: html_url, upload_url });
+        const { html_url, upload_url, id, discussion_url } = response.data;
+        this.setContext({
+          isReleased: true,
+          releaseId: id,
+          releaseUrl: html_url,
+          upload_url,
+          discussionUrl: discussion_url
+        });
+        this.config.setContext({
+          isReleased: true,
+          releaseId: id,
+          releaseUrl: html_url,
+          upload_url,
+          discussionUrl: discussion_url
+        });
         this.log.verbose(`octokit repos.createRelease: done (${response.headers.location})`);
         return response.data;
       } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "chalk": "5.3.0",
         "ci-info": "^4.0.0",
         "cosmiconfig": "9.0.0",
-        "execa": "8.0.1",
+        "execa": "8.0.0",
         "git-url-parse": "14.0.0",
         "globby": "14.0.2",
         "inquirer": "9.3.2",
@@ -3392,9 +3392,10 @@
       }
     },
     "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.0.tgz",
+      "integrity": "sha512-CTNS0BcKBcoOsawKBlpcKNmK4Kjuyz5jVLhf+PUsHGMqiKMVTa4cN3U7r7bRY8KTpfOGpXMo27fdy0dYVg2pqA==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "chalk": "5.3.0",
     "ci-info": "^4.0.0",
     "cosmiconfig": "9.0.0",
-    "execa": "8.0.1",
+    "execa": "8.0.0",
     "git-url-parse": "14.0.0",
     "globby": "14.0.2",
     "inquirer": "9.3.2",

--- a/schema/github.json
+++ b/schema/github.json
@@ -34,15 +34,7 @@
     },
     "discussionCategoryName": {
       "$comment": "Add discussion to the GitHub discussion for the Release",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        }
-      ],
-      "default": false
+      "type": "string"
     },
     "tokenRef": {
       "type": "string",

--- a/schema/github.json
+++ b/schema/github.json
@@ -32,6 +32,18 @@
       "type": "boolean",
       "default": false
     },
+    "discussionCategoryName": {
+      "$comment": "Add discussion to the GitHub discussion for the Release",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": false
+    },
     "tokenRef": {
       "type": "string",
       "default": "GITHUB_TOKEN"

--- a/test/github.js
+++ b/test/github.js
@@ -531,8 +531,8 @@ test('should create auto-generated discussion', async t => {
     body: {
       tag_name: '2.0.2',
       name: 'Release 2.0.2',
-      generate_release_notes: true,
-      body: '',
+      generate_release_notes: false,
+      body: null,
       discussion_category_name: 'Announcement'
     }
   });

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -47,10 +47,11 @@ const interceptCreate = ({
   body: {
     tag_name,
     name = '',
-    generate_release_notes = false,
     body = null,
     prerelease = false,
     draft = false,
+    generate_release_notes = false,
+    make_latest = 'true',
     discussion_category_name = false
   }
 } = {}) => {
@@ -62,7 +63,7 @@ const interceptCreate = ({
       prerelease,
       draft,
       generate_release_notes,
-      make_latest: 'true',
+      make_latest,
       discussion_category_name
     })
     .reply(() => {
@@ -88,7 +89,16 @@ const interceptUpdate = ({
   api = 'https://api.github.com',
   owner = 'user',
   project = 'repo',
-  body: { tag_name, name = '', body = null, prerelease = false, draft = false, generate_release_notes = false }
+  body: {
+    tag_name,
+    name = '',
+    body = null,
+    prerelease = false,
+    draft = false,
+    generate_release_notes = false,
+    make_latest = 'true',
+    discussion_category_name = false
+  }
 } = {}) => {
   nock(api)
     .patch(`/repos/${owner}/${project}/releases/1`, {
@@ -98,7 +108,8 @@ const interceptUpdate = ({
       draft,
       prerelease,
       generate_release_notes,
-      make_latest: 'true'
+      make_latest,
+      discussion_category_name
     })
     .reply(200, {
       id: 1,

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -51,7 +51,7 @@ const interceptCreate = ({
     body = null,
     prerelease = false,
     draft = false,
-    discussion_category_name = 'announcement'
+    discussion_category_name = false
   }
 } = {}) => {
   nock(api)
@@ -87,15 +87,7 @@ const interceptUpdate = ({
   api = 'https://api.github.com',
   owner = 'user',
   project = 'repo',
-  body: {
-    tag_name,
-    name = '',
-    body = null,
-    prerelease = false,
-    draft = false,
-    generate_release_notes = false,
-    discussion_category_name = false
-  }
+  body: { tag_name, name = '', body = null, prerelease = false, draft = false, generate_release_notes = false }
 } = {}) => {
   nock(api)
     .patch(`/repos/${owner}/${project}/releases/1`, {
@@ -105,8 +97,7 @@ const interceptUpdate = ({
       draft,
       prerelease,
       generate_release_notes,
-      make_latest: 'true',
-      discussion_category_name
+      make_latest: 'true'
     })
     .reply(200, {
       id: 1,

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -44,7 +44,15 @@ const interceptCreate = ({
   host = 'github.com',
   owner = 'user',
   project = 'repo',
-  body: { tag_name, name = '', generate_release_notes = false, body = null, prerelease = false, draft = false }
+  body: {
+    tag_name,
+    name = '',
+    generate_release_notes = false,
+    body = null,
+    prerelease = false,
+    draft = false,
+    discussion_category_name = 'announcement'
+  }
 } = {}) => {
   nock(api)
     .post(`/repos/${owner}/${project}/releases`, {
@@ -54,7 +62,8 @@ const interceptCreate = ({
       prerelease,
       draft,
       generate_release_notes,
-      make_latest: 'true'
+      make_latest: 'true',
+      discussion_category_name
     })
     .reply(() => {
       const id = 1;
@@ -78,7 +87,15 @@ const interceptUpdate = ({
   api = 'https://api.github.com',
   owner = 'user',
   project = 'repo',
-  body: { tag_name, name = '', body = null, prerelease = false, draft = false, generate_release_notes = false }
+  body: {
+    tag_name,
+    name = '',
+    body = null,
+    prerelease = false,
+    draft = false,
+    generate_release_notes = false,
+    discussion_category_name = false
+  }
 } = {}) => {
   nock(api)
     .patch(`/repos/${owner}/${project}/releases/1`, {
@@ -88,7 +105,8 @@ const interceptUpdate = ({
       draft,
       prerelease,
       generate_release_notes,
-      make_latest: 'true'
+      make_latest: 'true',
+      discussion_category_name
     })
     .reply(200, {
       id: 1,

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -76,7 +76,8 @@ const interceptCreate = ({
         draft,
         generate_release_notes,
         upload_url: `https://uploads.${host}/repos/${owner}/${project}/releases/${id}/assets{?name,label}`,
-        html_url: `https://${host}/${owner}/${project}/releases/tag/${tag_name}`
+        html_url: `https://${host}/${owner}/${project}/releases/tag/${tag_name}`,
+        discussion_url: discussion_category_name ? `https://${host}/${owner}/${project}/discussions/${id}` : undefined
       };
       return [200, responseBody, { location: `${api}/repos/${owner}/${project}/releases/${id}` }];
     });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -140,6 +140,9 @@ export interface Config {
     makeLatest?: boolean | 'legacy';
 
     /** @default false */
+    discussionCategoryName?: boolean | string;
+
+    /** @default false */
     skipChecks?: boolean;
 
     /** @default false */


### PR DESCRIPTION
## Closes #1159

In my open source projects, I am extensively using release-it. Before that I used to use GitHub Action to make the release on GitHub which also created GitHub discussion for me.

But when I started using release-it, I did not found any option to auto create GitHub discussion on GitHub release.

With this PR, `discussion_category_name` has been exposed to the [GitHub API](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release).

Hopefully this feature would be helpful to others.