### PR TITLE
feat: create tag via Gitlab release (#1115)

### DIFF
--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -189,10 +189,11 @@ class GitLab extends Release {
 
   async createRelease() {
     const { releaseName } = this.options;
-    const { tagName } = this.config.getContext();
+    const { tagName, branchName, git: { tagAnnotation } = {} } = this.config.getContext();
     const { id, releaseNotes, repo, origin } = this.getContext();
     const { isDryRun } = this.config;
     const name = format(releaseName, this.config.getContext());
+    const tagMessage = format(tagAnnotation, this.config.getContext());
     const description = releaseNotes || '-';
     const releaseUrl = `${origin}/${repo.repository}/-/releases`;
     const releaseMilestones = this.getReleaseMilestones();
@@ -208,7 +209,9 @@ class GitLab extends Release {
     const options = {
       json: {
         name,
+        ref: branchName,
         tag_name: tagName,
+        tag_message: tagMessage,
         description
       }
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,11 +6384,11 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import test from 'ava';
 import sinon from 'sinon';
 import nock from 'nock';
+import { isCI } from 'ci-info';
+import Git from '../lib/plugin/git/Git.js';
 import GitLab from '../lib/plugin/gitlab/GitLab.js';
 import { factory, runTasks } from './util/index.js';
 import {
@@ -63,6 +65,9 @@ test.serial('should upload assets and release', async t => {
   const gitlab = factory(GitLab, { options });
   sinon.stub(gitlab, 'getLatestVersion').resolves('2.0.0');
 
+  const git = factory(Git, { options });
+  const branchName = await git.getBranchName();
+
   interceptUser();
   interceptCollaborator();
   interceptMilestones({
@@ -89,7 +94,9 @@ test.serial('should upload assets and release', async t => {
   interceptPublish({
     body: {
       name: 'Release 2.0.1',
+      ref: isCI ? 'HEAD' : branchName,
       tag_name: '2.0.1',
+      tag_message: 'Release 2.0.1',
       description: 'Custom notes',
       assets: {
         links: [

--- a/test/tasks.interactive.js
+++ b/test/tasks.interactive.js
@@ -171,7 +171,9 @@ test.serial('should run "after:*:release" plugin hooks', async t => {
     project,
     body: {
       name: 'Release 1.1.0',
+      ref: 'master',
       tag_name: '1.1.0',
+      tag_message: 'Release 1.1.0',
       description: `* More file (${sha})`
     }
   });

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -270,7 +270,9 @@ test.serial('should release all the things (pre-release, github, gitlab)', async
     project,
     body: {
       name: 'Release 1.1.0-alpha.0',
+      ref: 'master',
       tag_name: 'v1.1.0-alpha.0',
+      tag_message: `${owner} ${owner}/${project} ${project}`,
       description: `Notes for ${pkgName}: ${sha}`,
       assets: {
         links: [


### PR DESCRIPTION
Replacement for release-it#1116  as per https://github.com/release-it/release-it/pull/1116#issuecomment-2405765425 with:

- Functional unit tests. 🤞 
- Support for `tag_message` to [GitLab API](https://docs.gitlab.com/ee/api/releases/#create-a-release) via `git.tagAnnotation`.