### PR TITLE
Add proper Content-Type header to fetch requests

### DIFF
--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -165,6 +165,7 @@ class GitLab extends Release {
     const url = `${baseUrl}/${endpoint}${options.searchParams ? `?${new URLSearchParams(options.searchParams)}` : ''}`;
     const headers = {
       'user-agent': 'webpro/release-it',
+      'Content-Type': typeof options.json !== "undefined" ? 'application/json' : 'text/plain',
       [tokenHeader]: this.token
     };
     const requestOptions = {


### PR DESCRIPTION
The `got` npm package [sets the proper](https://github.com/sindresorhus/got/blob/main/documentation/quick-start.md?plain=1#L60) `Content-Type` header when the body of a request is set to `json`. This behavior [was not ported](https://github.com/release-it/release-it/commit/696f0821fa871a794dba9eabdcc960554f073eab#diff-44f297bf9ddf782cf7057c9b2755dedcb77fd7e168cbd354690eb933a9b5022bR166-R169) when `got` and `node-fetch` were removed in favor of NodeJS' native `fetch` API.

This PR fixes this.