### PR TITLE
[Issue#1137] Fixed GitBase.getLatestVersion to computed formatted tagTemplate befo…

### DIFF
--- a/lib/plugin/GitBase.js
+++ b/lib/plugin/GitBase.js
@@ -27,7 +27,7 @@ class GitBase extends Plugin {
 
   getLatestVersion() {
     const { tagTemplate, latestTag } = this.config.getContext();
-    const prefix = tagTemplate.replace(/\$\{version\}/, '');
+    const prefix = format(tagTemplate.replace(/\$\{version\}/, ''), this.config.getContext());
     return latestTag ? latestTag.replace(prefix, '').replace(/^v/, '') : null;
   }
 


### PR DESCRIPTION
…re using it for latestTag computation

This fixes the issue reported in https://github.com/release-it/release-it/issues/1137