### PR TITLE
feat: add capability to add extends configuration to release-it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,16 +91,16 @@ Release-it has [plenty of options][2]. See the following tables for plugin confi
 
 You can extend a configuration from a remote source using the `extends` option. The following formats are supported:
 
-- `github>owner/repo`
-- `github>owner/repo#tag`
-- `github>owner/repo:file#tag`
+- `github:owner/repo`
+- `github:owner/repo#tag`
+- `github:owner/repo:file#tag`
 
 For example, to extend a configuration from a GitHub repository:
 
 ```json
 {
-  "$schema": "https://unpkg.com/release-it@17/schema/release-it.json",
-  "extends": "github>release-it/release-it-configuration"
+  "$schema": "https://unpkg.com/release-it@18/schema/release-it.json",
+  "extends": "github:release-it/release-it-configuration"
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,25 @@ Release-it has [plenty of options][2]. See the following tables for plugin confi
 - [GitHub][5]
 - [GitLab][6]
 
+### Extend Configuration
+
+You can extend a configuration from a remote source using the `extends` option. The following formats are supported:
+
+- `github>owner/repo`
+- `github>owner/repo#tag`
+- `github>owner/repo:file#tag`
+
+For example, to extend a configuration from a GitHub repository:
+
+```json
+{
+  "$schema": "https://unpkg.com/release-it@17/schema/release-it.json",
+  "extends": "github>release-it/release-it-configuration"
+}
+```
+
+Only public GitHub repositories are supported at this time.
+
 ## Setting options via CLI
 
 Any option can also be set on the command-line, and will have highest priority. Example:

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,17 +41,17 @@ const getLocalConfig = ({ file, dir = process.cwd() }) => {
   return result && isObjectStrict(result.config) ? result.config : localConfig;
 };
 
-const fetchConfigurationFromGitHub = async pattern => {
+const fetchConfigurationFromGitHub = async configuration => {
   const regex = /^github:([^/]+)\/([^#:]+)(?::([^#]+))?(?:#(.+))?$/;
-  const match = pattern.match(regex);
+  const match = configuration.match(regex);
 
   if (!match) {
-    throw new Error('Invalid Extended Configuration from GitHub');
+    throw new Error(`Invalid Extended Configuration from GitHub: ${configuration}`);
   }
 
   const [, owner, repo, file = '.release-it.json', tag] = match;
-  const branchOrTag = tag ? `refs/tags/${tag}` : 'HEAD';
-  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branchOrTag}/${file}`;
+  const ref = tag ? `refs/tags/${tag}` : 'HEAD';
+  const url = new URL(`https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${file}`);
 
   const response = await fetch(url);
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,7 @@ import defaultsDeep from '@nodeutils/defaults-deep';
 import { isObjectStrict } from '@phun-ky/typeof';
 import merge from 'lodash.merge';
 import get from 'lodash.get';
-import { readJSON, getSystemInfo } from './util.js';
+import { e, getSystemInfo, readJSON } from './util.js';
 
 const debug = util.debug('release-it:config');
 const defaultConfig = readJSON(new URL('../config/release-it.json', import.meta.url));
@@ -42,11 +42,13 @@ const getLocalConfig = ({ file, dir = process.cwd() }) => {
 };
 
 const fetchConfigurationFromGitHub = async configuration => {
+  const docs = 'https://github.com/release-it/release-it/blob/main/docs/configuration.md';
+
   const regex = /^github:([^/]+)\/([^#:]+)(?::([^#]+))?(?:#(.+))?$/;
   const match = configuration.match(regex);
 
   if (!match) {
-    throw new Error(`Invalid Extended Configuration from GitHub: ${configuration}`);
+    throw e(`Invalid Extended Configuration from GitHub: ${configuration}`, docs);
   }
 
   const [, owner, repo, file = '.release-it.json', tag] = match;
@@ -56,7 +58,7 @@ const fetchConfigurationFromGitHub = async configuration => {
   const response = await fetch(url);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+    throw e(`Failed to fetch ${url}: ${response.statusText}`, docs);
   }
 
   return response.json();

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,8 +38,32 @@ const getLocalConfig = ({ file, dir = process.cwd() }) => {
     throw new Error(`Invalid configuration file at ${result.filepath}`);
   }
   debug({ cosmiconfig: result });
-
   return result && isObjectStrict(result.config) ? result.config : localConfig;
+};
+
+const fetchConfigurationFromGitHub = async pattern => {
+  const regex = /^github>([^/]+)\/([^#:]+)(?::([^#]+))?(?:#(.+))?$/;
+  const match = pattern.match(regex);
+
+  if (!match) {
+    throw new Error('Invalid Extended Configuration from GitHub');
+  }
+
+  const [, owner, repo, file = '.release-it.json', tag] = match;
+  const branchOrTag = tag ? `refs/tags/${tag}` : 'HEAD';
+  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branchOrTag}/${file}`;
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+  }
+
+  return response.json();
+};
+
+const getRemoteConfiguration = async configuration => {
+  return fetchConfigurationFromGitHub(configuration);
 };
 
 class Config {
@@ -85,6 +109,10 @@ class Config {
       this.localConfig,
       this.defaultConfig
     );
+  }
+
+  mergeRemoteOptions(remoteConfiguration) {
+    return merge({}, this.options, remoteConfiguration);
   }
   getContext(path) {
     const context = merge({}, this.options, this.contextOptions);
@@ -140,5 +168,7 @@ class Config {
     return Boolean(this.options['changelog']);
   }
 }
+
+export { getRemoteConfiguration };
 
 export default Config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,7 @@ const getLocalConfig = ({ file, dir = process.cwd() }) => {
 };
 
 const fetchConfigurationFromGitHub = async pattern => {
-  const regex = /^github>([^/]+)\/([^#:]+)(?::([^#]+))?(?:#(.+))?$/;
+  const regex = /^github:([^/]+)\/([^#:]+)(?::([^#]+))?(?:#(.+))?$/;
   const match = pattern.match(regex);
 
   if (!match) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const runTasks = async (opts, di) => {
     Object.assign(container, di);
     container.config = container.config || new Config(opts);
 
-    if ('extends' in container.config.options) {
+    if (typeof container.config.options?.extends === 'string') {
       /**
        * If the configuration has an 'extends' property, fetch the remote configuration
        * and merge it into the local configuration options.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import { getPlugins } from './plugin/factory.js';
 import Logger from './log.js';
-import Config from './config.js';
+import Config, { getRemoteConfiguration } from './config.js';
 import Shell from './shell.js';
 import Prompt from './prompt.js';
 import Spinner from './spinner.js';
@@ -12,6 +12,15 @@ const runTasks = async (opts, di) => {
   try {
     Object.assign(container, di);
     container.config = container.config || new Config(opts);
+
+    if ('extends' in container.config.options) {
+      /**
+       * If the configuration has an 'extends' property, fetch the remote configuration
+       * and merge it into the local configuration options.
+       */
+      const remoteConfiguration = await getRemoteConfiguration(container.config.options.extends);
+      container.config.options = container.config.mergeRemoteOptions(remoteConfiguration);
+    }
 
     const { config } = container;
     const { isCI, isVerbose, verbosityLevel, isDryRun, isChangelog, isReleaseVersion } = config;

--- a/schema/release-it.json
+++ b/schema/release-it.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "The JSON schema version used to validate this configuration file"
     },
+    "extends": {
+      "type": "string",
+      "description": "URL that specifies a configuration to extend"
+    },
     "hooks": {
       "type": "object",
       "additionalProperties": true,

--- a/test/config.js
+++ b/test/config.js
@@ -168,7 +168,7 @@ test('should expand pre-release shortcut (snapshot)', t => {
 test.serial('should fetch extended configuration with default file and default branch', async t => {
   const fetchStub = sandbox.stub(global, 'fetch');
   const config = {
-    extends: 'github>release-it/release-it-configuration'
+    extends: 'github:release-it/release-it-configuration'
   };
 
   const extendedConfiguration = {
@@ -194,7 +194,7 @@ test.serial('should fetch extended configuration with default file and default b
 test.serial('should fetch extended configuration with default file and specific tag', async t => {
   const fetchStub = sandbox.stub(global, 'fetch');
   const config = {
-    extends: 'github>release-it/release-it-configuration#1.0.0'
+    extends: 'github:release-it/release-it-configuration#1.0.0'
   };
 
   const extendedConfiguration = {
@@ -221,7 +221,7 @@ test.serial('should fetch extended configuration with default file and specific 
 test.serial('should fetch extended configuration with custom file and specific tag', async t => {
   const fetchStub = sandbox.stub(global, 'fetch');
   const config = {
-    extends: 'github>release-it/release-it-configuration:config.json#1.0.0'
+    extends: 'github:release-it/release-it-configuration:config.json#1.0.0'
   };
 
   const extendedConfiguration = {
@@ -248,7 +248,7 @@ test.serial('should fetch extended configuration with custom file and specific t
 test.serial('should fetch extended configuration with custom file and default branch', async t => {
   const fetchStub = sandbox.stub(global, 'fetch');
   const config = {
-    extends: 'github>release-it/release-it-configuration:config.json'
+    extends: 'github:release-it/release-it-configuration:config.json'
   };
 
   const extendedConfiguration = {

--- a/test/config.js
+++ b/test/config.js
@@ -185,9 +185,10 @@ test.serial('should fetch extended configuration with default file and default b
   const response = await getRemoteConfiguration(config.extends);
 
   t.is(
-    fetchStub.lastCall.args[0],
+    fetchStub.firstCall.firstArg.href,
     'https://raw.githubusercontent.com/release-it/release-it-configuration/HEAD/.release-it.json'
   );
+
   t.is(response, extendedConfiguration);
 });
 
@@ -211,7 +212,7 @@ test.serial('should fetch extended configuration with default file and specific 
   const response = await getRemoteConfiguration(config.extends);
 
   t.is(
-    fetchStub.lastCall.args[0],
+    fetchStub.firstCall.firstArg.href,
     'https://raw.githubusercontent.com/release-it/release-it-configuration/refs/tags/1.0.0/.release-it.json'
   );
 
@@ -238,7 +239,7 @@ test.serial('should fetch extended configuration with custom file and specific t
   const response = await getRemoteConfiguration(config.extends);
 
   t.is(
-    fetchStub.lastCall.args[0],
+    fetchStub.firstCall.firstArg.href,
     'https://raw.githubusercontent.com/release-it/release-it-configuration/refs/tags/1.0.0/config.json'
   );
 
@@ -265,7 +266,7 @@ test.serial('should fetch extended configuration with custom file and default br
   const response = await getRemoteConfiguration(config.extends);
 
   t.is(
-    fetchStub.lastCall.args[0],
+    fetchStub.firstCall.firstArg.href,
     'https://raw.githubusercontent.com/release-it/release-it-configuration/HEAD/config.json'
   );
 

--- a/test/tasks.interactive.js
+++ b/test/tasks.interactive.js
@@ -114,9 +114,34 @@ test.serial('should run tasks using extended configuration', async t => {
 
   const { name, latestVersion, version } = await runTasks({}, container);
 
+  t.is(fetchStub.callCount, 1);
+
   const commands = exec.args.flat().filter(arg => typeof arg === 'string' && arg.startsWith('echo'));
 
   t.true(commands.includes(validationExtendedConfiguration));
+
+  t.is(version, '0.0.1');
+  t.true(log.obtrusive.firstCall.args[0].includes(`release ${name} (currently at ${latestVersion})`));
+  t.regex(log.log.lastCall.args[0], /Done \(in [0-9]+s\.\)/);
+
+  fetchStub.restore();
+});
+
+test.serial('should run tasks not using extended configuration as it is not a string', async t => {
+  renameSync('.git', 'foo');
+
+  const fetchStub = sandbox.stub(global, 'fetch');
+
+  const config = {
+    $schema: 'https://unpkg.com/release-it@17/schema/release-it.json',
+    extends: false
+  };
+
+  const container = getContainer(config);
+
+  const { name, latestVersion, version } = await runTasks({}, container);
+
+  t.is(fetchStub.callCount, 0);
 
   t.is(version, '0.0.1');
   t.true(log.obtrusive.firstCall.args[0].includes(`release ${name} (currently at ${latestVersion})`));

--- a/test/tasks.interactive.js
+++ b/test/tasks.interactive.js
@@ -104,8 +104,8 @@ test.serial('should run tasks using extended configuration', async t => {
   });
 
   const config = {
-    $schema: 'https://unpkg.com/release-it@17/schema/release-it.json',
-    extends: 'github>release-it/release-it-configuration'
+    $schema: 'https://unpkg.com/release-it@18/schema/release-it.json',
+    extends: 'github:release-it/release-it-configuration'
   };
 
   const container = getContainer(config);
@@ -133,7 +133,7 @@ test.serial('should run tasks not using extended configuration as it is not a st
   const fetchStub = sandbox.stub(global, 'fetch');
 
   const config = {
-    $schema: 'https://unpkg.com/release-it@17/schema/release-it.json',
+    $schema: 'https://unpkg.com/release-it@18/schema/release-it.json',
     extends: false
   };
 

--- a/test/tasks.interactive.js
+++ b/test/tasks.interactive.js
@@ -89,6 +89,42 @@ test.serial('should run tasks without throwing errors', async t => {
   t.regex(log.log.lastCall.args[0], /Done \(in [0-9]+s\.\)/);
 });
 
+test.serial('should run tasks using extended configuration', async t => {
+  renameSync('.git', 'foo');
+
+  const validationExtendedConfiguration = "echo 'extended_configuration'";
+
+  const fetchStub = sandbox.stub(global, 'fetch').resolves({
+    ok: true,
+    json: async () => ({
+      hooks: {
+        'before:init': validationExtendedConfiguration
+      }
+    })
+  });
+
+  const config = {
+    $schema: 'https://unpkg.com/release-it@17/schema/release-it.json',
+    extends: 'github>release-it/release-it-configuration'
+  };
+
+  const container = getContainer(config);
+
+  const exec = sandbox.spy(container.shell, 'execFormattedCommand');
+
+  const { name, latestVersion, version } = await runTasks({}, container);
+
+  const commands = exec.args.flat().filter(arg => typeof arg === 'string' && arg.startsWith('echo'));
+
+  t.true(commands.includes(validationExtendedConfiguration));
+
+  t.is(version, '0.0.1');
+  t.true(log.obtrusive.firstCall.args[0].includes(`release ${name} (currently at ${latestVersion})`));
+  t.regex(log.log.lastCall.args[0], /Done \(in [0-9]+s\.\)/);
+
+  fetchStub.restore();
+});
+
 test.serial('should not run hooks for disabled release-cycle methods', async t => {
   const hooks = getHooks(['version', 'git', 'github', 'gitlab', 'npm']);
 


### PR DESCRIPTION
This pull request introduces the ability to extend configuration from a remote source, specifically GitHub repositories, and includes several related changes to the codebase, documentation, and tests.

### New Feature: Extend Configuration

* [`docs/configuration.md`](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R90-R108): Added documentation for the new `extends` option that allows extending configurations from remote GitHub repositories.
* [`schema/release-it.json`](diffhunk://#diff-351d879d6af18de4b75acfc02e1d443c8ffb3438f9d1176537f8eafeb7e46f4dR12-R15): Added the `extends` property to the JSON schema to specify a configuration to extend.

### Code Changes

* [`lib/config.js`](diffhunk://#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62L6-R6): Introduced `fetchConfigurationFromGitHub` and `getRemoteConfiguration` functions to fetch and merge remote configurations. Updated the `Config` class to include `mergeRemoteOptions` method. [[1]](diffhunk://#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62L6-R6) [[2]](diffhunk://#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62R41-R67) [[3]](diffhunk://#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62R113-R116) [[4]](diffhunk://#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62R172-R173)
* [`lib/index.js`](diffhunk://#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1L4-R4): Updated the `runTasks` function to fetch and merge remote configurations if the `extends` property is present. [[1]](diffhunk://#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1L4-R4) [[2]](diffhunk://#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R17-R25)

### Tests

* [`test/config.js`](diffhunk://#diff-324e5ae6ed1d64846d943bc35a8a7394f2099af356ca5d9e30413648a3ae124fL3-R17): Added tests to verify fetching extended configurations from GitHub with various scenarios (default file, specific tag, custom file). [[1]](diffhunk://#diff-324e5ae6ed1d64846d943bc35a8a7394f2099af356ca5d9e30413648a3ae124fL3-R17) [[2]](diffhunk://#diff-324e5ae6ed1d64846d943bc35a8a7394f2099af356ca5d9e30413648a3ae124fR167-R274)
* [`test/tasks.interactive.js`](diffhunk://#diff-d71ed2d617b85d6178e3de2af9db613af912bb4ea00248178ed8d868e21d710aR93-R153): Added tests to ensure tasks run correctly with and without extended configurations.