### PR TITLE
fix(gitlab): don't set Content-Type header when uploading release assets

### DIFF
--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -165,9 +165,13 @@ class GitLab extends Release {
     const url = `${baseUrl}/${endpoint}${options.searchParams ? `?${new URLSearchParams(options.searchParams)}` : ''}`;
     const headers = {
       'user-agent': 'webpro/release-it',
-      'Content-Type': typeof options.json !== 'undefined' ? 'application/json' : 'text/plain',
       [tokenHeader]: this.token
     };
+    // When using fetch() with FormData bodies, we should not set the Content-Type header.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects#sending_files_using_a_formdata_object
+    if (!(options.body instanceof FormData)) {
+      headers['Content-Type'] = typeof options.json !== 'undefined' ? 'application/json' : 'text/plain';
+    }
     const requestOptions = {
       method,
       headers,


### PR DESCRIPTION
As noted in [a comment on #1172][1], switching to the use of the native fetch API broke uploading release assets to GitLab by hard-coding the Content-Type header to "text/plain". The [recommended approach][2] is to avoid setting the Content-Type header at all and let the fetch API implementation set it so as to ensure that the correct boundary expression is included.

~~Add a flag to the `request` function to allow explicitly disabling setting the Content-Type header.~~ Update the `request` function to avoid setting the Content-Type header if the body is an instance of `FormData`. The default behaviour is to set the header as before but we disable setting the header only in the `uploadAsset` function.

The bug is blocking a [feature in our product](https://gitlab.developers.cam.ac.uk/uis/devops/iam/activate-account/api/-/issues/30) and I've checked that the change in this PR fixes our observed issue with GitLab release asset uploads. Using the branch from this PR, I am able to create a release with the expected assets in a test project.

[1]: https://github.com/release-it/release-it/issues/1172#issuecomment-2468592425
[2]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects#sending_files_using_a_formdata_object

Closes #1172