### PR TITLE
GitLab Generic Package Repository for assets

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -67,6 +67,7 @@
     "assets": null,
     "useIdsForUrls": false,
     "useGenericPackageRepositoryForAssets": false,
+    "projectId": null,
     "genericPackageRepositoryName": "release-it",
     "origin": null,
     "skipChecks": false

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -66,6 +66,8 @@
     "secure": null,
     "assets": null,
     "useIdsForUrls": false,
+    "useGenericPackageRepositoryForAssets": false,
+    "genericPackageRepositoryName": "release-it",
     "origin": null,
     "skipChecks": false
   }

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -67,7 +67,6 @@
     "assets": null,
     "useIdsForUrls": false,
     "useGenericPackageRepositoryForAssets": false,
-    "projectId": null,
     "genericPackageRepositoryName": "release-it",
     "origin": null,
     "skipChecks": false

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -106,14 +106,13 @@ download from the project's releases page. Example:
 ```
 
 Version 17.2 of Gitlab [started enforcing a new URL format][6] for uploaded assets. If you are using this version (or
-later), you should set the `useIdsForUrls` flag to `true`. You can also set the `projectId` to the ID found in your repository settings. This is auto populated when using GitLab CI. If it isnt found in the Environment it will query Gitlab to get the project id:
+later), you should set the `useIdsForUrls` flag to `true`:
 
 ```json
 {
   "gitlab": {
     "release": true,
     "useIdsForUrls": true,
-    "projectId": "1234567890",
     "assets": ["dist/*.dmg"]
   }
 }
@@ -129,7 +128,6 @@ By default release assets are uploaded to the project's Markdown uploads API. If
     "release": true,
     "useGenericPackageRepositoryForAssets": true,
     "genericPackageRepositoryName": "release-it",
-    "projectId": "1234567890",
     "assets": ["dist/*.dmg"]
   }
 }

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -106,13 +106,14 @@ download from the project's releases page. Example:
 ```
 
 Version 17.2 of Gitlab [started enforcing a new URL format][6] for uploaded assets. If you are using this version (or
-later), you should set the `useIdsForUrls` flag to `true`:
+later), you should set the `useIdsForUrls` flag to `true`. You can also set the `projectId` to the ID found in your repository settings. This is auto populated when using GitLab CI. If it isnt found in the Environment it will query Gitlab to get the project id:
 
 ```json
 {
   "gitlab": {
     "release": true,
     "useIdsForUrls": true,
+    "projectId": "1234567890",
     "assets": ["dist/*.dmg"]
   }
 }
@@ -120,7 +121,7 @@ later), you should set the `useIdsForUrls` flag to `true`:
 
 ### Asset Location
 
-By default release assets are uploaded to the project's Markdown uploads API. If you want to use GitLab's Generic packages Repository set `useGenericPackageRepositoryForAssets` flag to true. `useIdsForUrls` is ignored from this API. You can set the package name to be uploaded to using `genericPackageRepositoryName` by default the name is `release-it`:
+By default release assets are uploaded to the project's Markdown uploads API. If you want to use GitLab's Generic packages Repository set `useGenericPackageRepositoryForAssets` flag to true. `useIdsForUrls` is ignored from this API. You can set the package name to be uploaded to using `genericPackageRepositoryName` by default the name is `release-it`.
 
 ```json
 {
@@ -128,6 +129,7 @@ By default release assets are uploaded to the project's Markdown uploads API. If
     "release": true,
     "useGenericPackageRepositoryForAssets": true,
     "genericPackageRepositoryName": "release-it",
+    "projectId": "1234567890",
     "assets": ["dist/*.dmg"]
   }
 }

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -118,6 +118,21 @@ later), you should set the `useIdsForUrls` flag to `true`:
 }
 ```
 
+### Asset Location
+
+By default release assets are uploaded to the project's Markdown uploads API. If you want to use GitLab's Generic packages Repository set `useGenericPackageRepositoryForAssets` flag to true. `useIdsForUrls` is ignored from this API. You can set the package name to be uploaded to using `genericPackageRepositoryName` by default the name is `release-it`:
+
+```json
+{
+  "gitlab": {
+    "release": true,
+    "useGenericPackageRepositoryForAssets": true,
+    "genericPackageRepositoryName": "release-it",
+    "assets": ["dist/*.dmg"]
+  }
+}
+```
+
 ## Origin
 
 The `origin` can be set to a string such as `"http://example.org:3000"` to use a different origin from what would be

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -271,7 +271,7 @@ class GitLab extends Release {
         await this.request(endpoint, options);
         this.log.verbose(`gitlab releases#uploadAsset: done (${endpoint})`);
         this.assets.push({
-          filePath,
+          name: filePath,
           url: `${origin}/${endpoint}`
         });
       } catch (err) {

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -289,8 +289,9 @@ class GitLab extends Release {
       };
       try {
         const body = await this.request(endpoint, options);
-        console.log('upload response: ', body);
-        console.log('context: ', this.getContext());
+        if (!(body.message && body.message == '201 Created')) {
+          throw new Error(`GitLab asset upload failed`);
+        }
         this.log.verbose(`gitlab releases#uploadAsset: done (${endpoint})`);
         this.assets.push({
           name: filePath,
@@ -321,7 +322,7 @@ class GitLab extends Release {
   }
 
   uploadAssets() {
-    const { assets } = this.options;
+    const { assets, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
     const { isDryRun } = this.config;
     const context = this.config.getContext();
 
@@ -340,7 +341,14 @@ class GitLab extends Release {
 
       if (isDryRun) return Promise.resolve();
 
-      return Promise.all(files.map(filePath => this.uploadAsset(filePath)));
+      return Promise.all(files.map(filePath => this.uploadAsset(filePath))).then(() => {
+        if (this.assets.length > 1 && useGenericPackageRepositoryForAssets) {
+          this.assets.push({
+            name: 'manifest.json',
+            url: `${context.baseUrl}/projects/${context.id}/packages/generic/${genericPackageRepositoryName}/${context.version}/files`
+          });
+        }
+      });
     });
   }
 }

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -32,14 +32,12 @@ class GitLab extends Release {
     await super.init();
 
     const { skipChecks, tokenRef, tokenHeader } = this.options;
-    let { projectId, useIdsForUrls } = this.options;
     const { repo } = this.getContext();
     const hasJobToken = (tokenHeader || '').toLowerCase() === 'job-token';
     const origin = this.options.origin || `https://${repo.host}`;
     this.setContext({
       id: encodeURIComponent(repo.repository),
       origin,
-      projectId,
       baseUrl: `${origin}/api/v4`
     });
 
@@ -56,23 +54,6 @@ class GitLab extends Release {
       if (!(await this.isCollaborator())) {
         const { user, repo } = this.getContext();
         throw e(`User ${user.username} is not a collaborator for ${repo.repository}.`, docs);
-      }
-      if (useIdsForUrls) {
-        if (projectId == null) {
-          projectId = _.get(process.env, 'CI_PROJECT_ID', null);
-          if (projectId == null) {
-            try {
-              const apiProject = await this.request(`/api/v4/projects/${encodeURIComponent(repo.repository)}`);
-              projectId = apiProject.id;
-            } catch (err) {
-              this.debug(err);
-              throw err;
-            }
-          }
-        }
-        this.setContext({
-          id: projectId
-        });
       }
     }
   }

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -57,6 +57,23 @@ class GitLab extends Release {
         const { user, repo } = this.getContext();
         throw e(`User ${user.username} is not a collaborator for ${repo.repository}.`, docs);
       }
+      if (useIdsForUrls) {
+        if (projectId == null) {
+          projectId = _.get(process.env, 'CI_PROJECT_ID', null);
+          if (projectId == null) {
+            try {
+              const apiProject = await this.request(`/api/v4/projects/${encodeURIComponent(repo.repository)}`);
+              projectId = apiProject.id;
+            } catch (err) {
+              this.debug(err);
+              throw err;
+            }
+          }
+        }
+        this.setContext({
+          id: projectId
+        });
+      }
     }
   }
 
@@ -304,7 +321,7 @@ class GitLab extends Release {
   }
 
   uploadAssets() {
-    const { assets, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
+    const { assets } = this.options;
     const { isDryRun } = this.config;
     const context = this.config.getContext();
 
@@ -323,14 +340,7 @@ class GitLab extends Release {
 
       if (isDryRun) return Promise.resolve();
 
-      return Promise.all(files.map(filePath => this.uploadAsset(filePath))).then(() => {
-        if (this.assets.length > 1 && useGenericPackageRepositoryForAssets) {
-          this.assets.push({
-            name: 'manifest.json',
-            url: `${context.baseUrl}/projects/${context.id}/packages/generic/${genericPackageRepositoryName}/${context.version}/files`
-          });
-        }
-      });
+      return Promise.all(files.map(filePath => this.uploadAsset(filePath))).then();
     });
   }
 }

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -278,7 +278,7 @@ class GitLab extends Release {
     const { id, origin, repo, version, projectId } = this.getContext();
     const endpoint = useGenericPackageRepositoryForAssets
       ? `projects/${useIdsForUrls ? projectId : id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
-      : `projects/${id}/uploads`;
+      : `projects/${useIdsForUrls ? projectId : id}/uploads`;
     if (useGenericPackageRepositoryForAssets) {
       const options = {
         method: 'PUT',

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -268,7 +268,9 @@ class GitLab extends Release {
         body: await fs.promises.readFile(filePath)
       };
       try {
-        await this.request(endpoint, options);
+        const body = await this.request(endpoint, options);
+        console.log('upload response: ', body);
+        console.log('context: ', this.getContext());
         this.log.verbose(`gitlab releases#uploadAsset: done (${endpoint})`);
         this.assets.push({
           name: filePath,

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -279,7 +279,7 @@ class GitLab extends Release {
     const { useIdsForUrls, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
     const { id, origin, repo, version, baseUrl } = this.getContext();
     const endpoint = useGenericPackageRepositoryForAssets
-      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
+      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${name}`
       : `projects/${id}/uploads`;
     if (useGenericPackageRepositoryForAssets) {
       const options = {
@@ -293,7 +293,7 @@ class GitLab extends Release {
         }
         this.log.verbose(`gitlab releases#uploadAsset: done (${endpoint})`);
         this.assets.push({
-          name: filePath,
+          name,
           url: `${baseUrl}/${endpoint}`
         });
       } catch (err) {
@@ -340,7 +340,7 @@ class GitLab extends Release {
 
       if (isDryRun) return Promise.resolve();
 
-      return Promise.all(files.map(filePath => this.uploadAsset(filePath))).then();
+      return Promise.all(files.map(filePath => this.uploadAsset(filePath)));
     });
   }
 }

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -276,11 +276,10 @@ class GitLab extends Release {
 
   async uploadAsset(filePath) {
     const name = path.basename(filePath);
-    const folderName = path.dirname(filePath);
     const { useIdsForUrls, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
     const { id, origin, repo, version, baseUrl } = this.getContext();
     const endpoint = useGenericPackageRepositoryForAssets
-      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${name}#${folderName}`
+      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
       : `projects/${id}/uploads`;
     if (useGenericPackageRepositoryForAssets) {
       const options = {

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -257,25 +257,44 @@ class GitLab extends Release {
 
   async uploadAsset(filePath) {
     const name = path.basename(filePath);
-    const { useIdsForUrls } = this.options;
-    const { id, origin, repo } = this.getContext();
-    const endpoint = `projects/${id}/uploads`;
+    const { useIdsForUrls, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
+    const { id, origin, repo, version } = this.getContext();
+    const endpoint = useGenericPackageRepositoryForAssets
+      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
+      : `projects/${id}/uploads`;
+    if (useGenericPackageRepositoryForAssets) {
+      const options = {
+        method: 'PUT',
+        body: await fs.promises.readFile(filePath)
+      };
+      try {
+        await this.request(endpoint, options);
+        this.log.verbose(`gitlab releases#uploadAsset: done (${endpoint})`);
+        this.assets.push({
+          filePath,
+          url: `${origin}/${endpoint}`
+        });
+      } catch (err) {
+        this.debug(err);
+        throw err;
+      }
+    } else {
+      const body = new FormData();
+      const rawData = await fs.promises.readFile(filePath);
+      body.set('file', new Blob([rawData]), name);
+      const options = { body };
 
-    const body = new FormData();
-    const rawData = await fs.promises.readFile(filePath);
-    body.set('file', new Blob([rawData]), name);
-    const options = { body };
-
-    try {
-      const body = await this.request(endpoint, options);
-      this.log.verbose(`gitlab releases#uploadAsset: done (${body.url})`);
-      this.assets.push({
-        name,
-        url: useIdsForUrls ? `${origin}${body.full_path}` : `${origin}/${repo.repository}${body.url}`
-      });
-    } catch (err) {
-      this.debug(err);
-      throw err;
+      try {
+        const body = await this.request(endpoint, options);
+        this.log.verbose(`gitlab releases#uploadAsset: done (${body.url})`);
+        this.assets.push({
+          name,
+          url: useIdsForUrls ? `${origin}${body.full_path}` : `${origin}/${repo.repository}${body.url}`
+        });
+      } catch (err) {
+        this.debug(err);
+        throw err;
+      }
     }
   }
 

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -32,7 +32,7 @@ class GitLab extends Release {
     await super.init();
 
     const { skipChecks, tokenRef, tokenHeader } = this.options;
-    let { projectId } = this.options;
+    let { projectId, useIdsForUrls } = this.options;
     const { repo } = this.getContext();
     const hasJobToken = (tokenHeader || '').toLowerCase() === 'job-token';
     const origin = this.options.origin || `https://${repo.host}`;
@@ -57,22 +57,24 @@ class GitLab extends Release {
         const { user, repo } = this.getContext();
         throw e(`User ${user.username} is not a collaborator for ${repo.repository}.`, docs);
       }
-    }
-    if (projectId == null) {
-      projectId = _.get(process.env, 'CI_PROJECT_ID', null);
-      if (projectId == null) {
-        try {
-          const apiProject = await this.request(`/api/v4/projects/${encodeURIComponent(repo.repository)}`);
-          projectId = apiProject.id;
-        } catch (err) {
-          this.debug(err);
-          throw err;
+      if (useIdsForUrls) {
+        if (projectId == null) {
+          projectId = _.get(process.env, 'CI_PROJECT_ID', null);
+          if (projectId == null) {
+            try {
+              const apiProject = await this.request(`/api/v4/projects/${encodeURIComponent(repo.repository)}`);
+              projectId = apiProject.id;
+            } catch (err) {
+              this.debug(err);
+              throw err;
+            }
+          }
         }
+        this.setContext({
+          id: projectId
+        });
       }
     }
-    this.setContext({
-      projectId
-    });
   }
 
   async isAuthenticated() {
@@ -274,11 +276,12 @@ class GitLab extends Release {
 
   async uploadAsset(filePath) {
     const name = path.basename(filePath);
+    const folderName = path.dirname(filePath);
     const { useIdsForUrls, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
-    const { id, origin, repo, version, projectId } = this.getContext();
+    const { id, origin, repo, version, baseUrl } = this.getContext();
     const endpoint = useGenericPackageRepositoryForAssets
-      ? `projects/${useIdsForUrls ? projectId : id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
-      : `projects/${useIdsForUrls ? projectId : id}/uploads`;
+      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${name}#${folderName}`
+      : `projects/${id}/uploads`;
     if (useGenericPackageRepositoryForAssets) {
       const options = {
         method: 'PUT',
@@ -291,7 +294,7 @@ class GitLab extends Release {
         this.log.verbose(`gitlab releases#uploadAsset: done (${endpoint})`);
         this.assets.push({
           name: filePath,
-          url: `${origin}/${endpoint}`
+          url: `${baseUrl}/${endpoint}`
         });
       } catch (err) {
         this.debug(err);

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -32,12 +32,14 @@ class GitLab extends Release {
     await super.init();
 
     const { skipChecks, tokenRef, tokenHeader } = this.options;
+    let { projectId } = this.options;
     const { repo } = this.getContext();
     const hasJobToken = (tokenHeader || '').toLowerCase() === 'job-token';
     const origin = this.options.origin || `https://${repo.host}`;
     this.setContext({
       id: encodeURIComponent(repo.repository),
       origin,
+      projectId,
       baseUrl: `${origin}/api/v4`
     });
 
@@ -56,6 +58,21 @@ class GitLab extends Release {
         throw e(`User ${user.username} is not a collaborator for ${repo.repository}.`, docs);
       }
     }
+    if (projectId == null) {
+      projectId = _.get(process.env, 'CI_PROJECT_ID', null);
+      if (projectId == null) {
+        try {
+          const apiProject = await this.request(`/api/v4/projects/${encodeURIComponent(repo.repository)}`);
+          projectId = apiProject.id;
+        } catch (err) {
+          this.debug(err);
+          throw err;
+        }
+      }
+    }
+    this.setContext({
+      projectId
+    });
   }
 
   async isAuthenticated() {
@@ -258,9 +275,9 @@ class GitLab extends Release {
   async uploadAsset(filePath) {
     const name = path.basename(filePath);
     const { useIdsForUrls, useGenericPackageRepositoryForAssets, genericPackageRepositoryName } = this.options;
-    const { id, origin, repo, version } = this.getContext();
+    const { id, origin, repo, version, projectId } = this.getContext();
     const endpoint = useGenericPackageRepositoryForAssets
-      ? `projects/${id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
+      ? `projects/${useIdsForUrls ? projectId : id}/packages/generic/${genericPackageRepositoryName}/${version}/${filePath}`
       : `projects/${id}/uploads`;
     if (useGenericPackageRepositoryForAssets) {
       const options = {

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -57,23 +57,6 @@ class GitLab extends Release {
         const { user, repo } = this.getContext();
         throw e(`User ${user.username} is not a collaborator for ${repo.repository}.`, docs);
       }
-      if (useIdsForUrls) {
-        if (projectId == null) {
-          projectId = _.get(process.env, 'CI_PROJECT_ID', null);
-          if (projectId == null) {
-            try {
-              const apiProject = await this.request(`/api/v4/projects/${encodeURIComponent(repo.repository)}`);
-              projectId = apiProject.id;
-            } catch (err) {
-              this.debug(err);
-              throw err;
-            }
-          }
-        }
-        this.setContext({
-          id: projectId
-        });
-      }
     }
   }
 

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -56,6 +56,14 @@
       "type": "boolean",
       "default": false
     },
+    "useGenericPackageRepositoryForAssets": {
+      "type": "boolean",
+      "default": false
+    },
+    "genericPackageRepositoryName": {
+       "type": "string",
+       "default": "release-it"
+    },
     "origin": {
       "type": "string",
       "default": null

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -56,10 +56,6 @@
       "type": "boolean",
       "default": false
     },
-    "projectId": {
-      "type": "string",
-      "default": null
-    },
     "useGenericPackageRepositoryForAssets": {
       "type": "boolean",
       "default": false

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -56,6 +56,10 @@
       "type": "boolean",
       "default": false
     },
+    "projectId": {
+      "type": "string",
+      "default": null
+    },
     "useGenericPackageRepositoryForAssets": {
       "type": "boolean",
       "default": false

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -10,6 +10,7 @@ import {
   interceptCollaborator,
   interceptPublish,
   interceptAsset,
+  interceptAssetGeneric,
   interceptMilestones
 } from './stub/gitlab.js';
 
@@ -140,6 +141,35 @@ test.serial('should upload assets with ID-based URLs too', async t => {
   await runTasks(gitlab);
 
   t.is(gitlab.assets[0].url, `${host}/-/project/1234/uploads/7e8bec1fe27cc46a4bc6a91b9e82a07c/file-v2.0.1.txt`);
+});
+
+test.serial('should upload assets to generic repo', async t => {
+  const host = 'https://gitlab.com';
+  const pushRepo = `${host}/user/repo`;
+  const options = {
+    git: { pushRepo },
+    gitlab: {
+      tokenRef,
+      release: true,
+      assets: 'test/resources/file-v${version}.txt',
+      useGenericPackageRepositoryForAssets: true,
+      genericPackageRepositoryName: 'release-it'
+    }
+  };
+  const gitlab = factory(GitLab, { options });
+  sinon.stub(gitlab, 'getLatestVersion').resolves('2.0.0');
+
+  interceptUser();
+  interceptCollaborator();
+  interceptAssetGeneric();
+  interceptPublish();
+
+  await runTasks(gitlab);
+
+  t.is(
+    gitlab.assets[0].url,
+    `${host}/projects/user%2Frepo/packages/generic/release-it/2.0.1/test/resources/file-v2.0.1.txt`
+  );
 });
 
 test.serial('should throw when release milestone is missing', async t => {

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -166,10 +166,7 @@ test.serial('should upload assets to generic repo', async t => {
 
   await runTasks(gitlab);
 
-  t.is(
-    gitlab.assets[0].url,
-    `${host}/projects/user%2Frepo/packages/generic/release-it/2.0.1/test/resources/file-v2.0.1.txt`
-  );
+  t.is(gitlab.assets[0].url, `${host}/api/v4/projects/user%2Frepo/packages/generic/release-it/2.0.1/file-v2.0.1.txt`);
 });
 
 test.serial('should throw when release milestone is missing', async t => {

--- a/test/stub/gitlab.js
+++ b/test/stub/gitlab.js
@@ -55,7 +55,7 @@ export let interceptAsset = ({ host = 'https://gitlab.com', owner = 'user', proj
 
 export let interceptAssetGeneric = ({ host = 'https://gitlab.com', owner = 'user', project = 'repo' } = {}) =>
   nock(host)
-    .put(`/api/v4/projects/${owner}%2F${project}/packages/generic/release-it/2.0.1/test/resources/file-v2.0.1.txt`)
+    .put(`/api/v4/projects/${owner}%2F${project}/packages/generic/release-it/2.0.1/file-v2.0.1.txt`)
     .reply(200, () => {
       return {
         message: '201 Created'

--- a/test/stub/gitlab.js
+++ b/test/stub/gitlab.js
@@ -52,3 +52,12 @@ export let interceptAsset = ({ host = 'https://gitlab.com', owner = 'user', proj
         }
       };
     });
+
+export let interceptAssetGeneric = ({ host = 'https://gitlab.com', owner = 'user', project = 'repo' } = {}) =>
+  nock(host)
+    .put(`/api/v4/projects/${owner}%2F${project}/packages/generic/release-it/2.0.1/test/resources/file-v2.0.1.txt`)
+    .reply(200, () => {
+      return {
+        message: '201 Created'
+      };
+    });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -190,6 +190,9 @@ export interface Config {
     /** @default false */
     useIdsForUrls?: boolean;
 
+    /** @default null */
+    projectId?: string;
+
     /** @default false */
     useGenericPackageRepositoryForAssets?: boolean;
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -190,9 +190,6 @@ export interface Config {
     /** @default false */
     useIdsForUrls?: boolean;
 
-    /** @default null */
-    projectId?: string;
-
     /** @default false */
     useGenericPackageRepositoryForAssets?: boolean;
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -190,6 +190,12 @@ export interface Config {
     /** @default false */
     useIdsForUrls?: boolean;
 
+    /** @default false */
+    useGenericPackageRepositoryForAssets?: boolean;
+
+    /** @default "release-it" */
+    genericPackageRepositoryName?: string;
+
     /** @default null */
     origin?: any;
 


### PR DESCRIPTION
This PR is for adding the ability to use GitLab's Generic Package Repository for uploading assets to the repo for use in the release. The current implementation uses the Markdown Uploads API which isnt ideal. That implementation is for use in wikis, readmes, etc. Using the Generic Package Repository is more inline with releases and allows more versioning control in the UI. 

By default, this feature will not change the default behavior so current implementations will not be broken. To use the new feature you set the option  `useGenericPackageRepositoryForAssets` to `true` (defaults to `false`) and you can define the package name by setting `genericPackageRepositoryName` (defaults to `release-it`). 

Fixes #1154 