### PR TITLE
Use URL to parse extended configuration string

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ import { isObjectStrict } from '@phun-ky/typeof';
 import merge from 'lodash.merge';
 import get from 'lodash.get';
 import { e, getSystemInfo, readJSON } from './util.js';
+import { join } from 'node:path';
 
 const debug = util.debug('release-it:config');
 const defaultConfig = readJSON(new URL('../config/release-it.json', import.meta.url));
@@ -44,21 +45,21 @@ const getLocalConfig = ({ file, dir = process.cwd() }) => {
 const fetchConfigurationFromGitHub = async configuration => {
   const docs = 'https://github.com/release-it/release-it/blob/main/docs/configuration.md';
 
-  const regex = /^github:([^/]+)\/([^#:]+)(?::([^#]+))?(?:#(.+))?$/;
-  const match = configuration.match(regex);
-
-  if (!match) {
+  let url;
+  try {
+    url = new URL(configuration);
+  } catch (e) {
     throw e(`Invalid Extended Configuration from GitHub: ${configuration}`, docs);
   }
 
-  const [, owner, repo, file = '.release-it.json', tag] = match;
-  const ref = tag ? `refs/tags/${tag}` : 'HEAD';
-  const url = new URL(`https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${file}`);
+  const ref = url.hash ? `refs/tags/${url.hash.replace(/^#/, '')}` : 'HEAD';
+  const [repo, file = '.release-it.json'] = url.pathname.split(':');
+  const rawUrl = new URL(join(repo, ref, file), 'https://raw.githubusercontent.com');
 
-  const response = await fetch(url);
+  const response = await fetch(rawUrl);
 
   if (!response.ok) {
-    throw e(`Failed to fetch ${url}: ${response.statusText}`, docs);
+    throw e(`Failed to fetch ${rawUrl}: ${response.statusText}`, docs);
   }
 
   return response.json();


### PR DESCRIPTION
Parse incoming extended config string using `new URL()`.

Coming from https://github.com/release-it/release-it/pull/1181#discussion_r2003592360

What do you think, @juancarlosjr97? This is what I had in mind, but happy to hear your thoughts here? The tests still pass, but maybe I'm missing certain edge or use cases?

Btw we've also moved to [mentoss](https://mentoss.dev) for mocking `fetch` requests which I think is quite nice :)