### PR TITLE
fix(json-schema): change `addUntrackedFiles` to boolean

### DIFF
--- a/schema/git.json
+++ b/schema/git.json
@@ -38,8 +38,8 @@
       "default": ""
     },
     "addUntrackedFiles": {
-      "type": "string",
-      "default": ""
+      "type": "boolean",
+      "default": false
     },
     "commit": {
       "type": "boolean",


### PR DESCRIPTION
The JSON Schema for the `git` plugin had `addUntrackedFiles` set as a string type when it should be a boolean. This leads to a warning when setting this option in `.release-it.json`. This only applies when a JSON file is used for configuration.

![Screenshot 2025-04-04 at 12 46 11 PM](https://github.com/user-attachments/assets/8f3a2123-da18-4d46-a8d5-f285918e7a6d)
