### PR TITLE
fix: parse boolean values from command line

### DIFF
--- a/bin/release-it.js
+++ b/bin/release-it.js
@@ -1,74 +1,11 @@
 #!/usr/bin/env node
 
 import updater from 'update-notifier';
-import parseArgs from 'yargs-parser';
 import release from '../lib/cli.js';
 import { readJSON } from '../lib/util.js';
+import { parseCliArguments } from '../lib/args.js';
 
 const pkg = readJSON(new URL('../package.json', import.meta.url));
-
-const aliases = {
-  c: 'config',
-  d: 'dry-run',
-  h: 'help',
-  i: 'increment',
-  v: 'version',
-  V: 'verbose'
-};
-
-const booleanOptions = [
-  'dry-run',
-  'ci',
-  'git',
-  'npm',
-  'github',
-  'gitlab',
-  'git.addUntrackedFiles',
-  'git.requireCleanWorkingDir',
-  'git.requireUpstream',
-  'git.requireCommits',
-  'git.requireCommitsFail',
-  'git.commit',
-  'git.tag',
-  'git.push',
-  'git.getLatestTagFromAllRefs',
-  'git.skipChecks',
-  'github.release',
-  'github.autoGenerate',
-  'github.preRelease',
-  'github.draft',
-  'github.skipChecks',
-  'github.web',
-  'github.comments.submit',
-  'gitlab.release',
-  'gitlab.autoGenerate',
-  'gitlab.preRelease',
-  'gitlab.draft',
-  'gitlab.useIdsForUrls',
-  'gitlab.useGenericPackageRepositoryForAssets',
-  'gitlab.skipChecks',
-  'npm.publish',
-  'npm.ignoreVersion',
-  'npm.allowSameVersion',
-  'npm.skipChecks'
-];
-
-const parseCliArguments = args => {
-  const options = parseArgs(args, {
-    boolean: booleanOptions,
-    alias: aliases,
-    configuration: {
-      'parse-numbers': false,
-      'camel-case-expansion': false
-    }
-  });
-  if (options.V) {
-    options.verbose = typeof options.V === 'boolean' ? options.V : options.V.length;
-    delete options.V;
-  }
-  options.increment = options._[0] || options.i;
-  return options;
-};
 
 const options = parseCliArguments([].slice.call(process.argv, 2));
 

--- a/bin/release-it.js
+++ b/bin/release-it.js
@@ -16,9 +16,46 @@ const aliases = {
   V: 'verbose'
 };
 
+const booleanOptions = [
+  'dry-run',
+  'ci',
+  'git',
+  'npm',
+  'github',
+  'gitlab',
+  'git.addUntrackedFiles',
+  'git.requireCleanWorkingDir',
+  'git.requireUpstream',
+  'git.requireCommits',
+  'git.requireCommitsFail',
+  'git.commit',
+  'git.tag',
+  'git.push',
+  'git.getLatestTagFromAllRefs',
+  'git.skipChecks',
+  'github.release',
+  'github.autoGenerate',
+  'github.preRelease',
+  'github.draft',
+  'github.skipChecks',
+  'github.web',
+  'github.comments.submit',
+  'gitlab.release',
+  'gitlab.autoGenerate',
+  'gitlab.preRelease',
+  'gitlab.draft',
+  'gitlab.useIdsForUrls',
+  'gitlab.useGenericPackageRepositoryForAssets',
+  'gitlab.skipChecks',
+  'npm.publish',
+  'npm.ignoreVersion',
+  'npm.allowSameVersion',
+  'npm.skipChecks'
+];
+
 const parseCliArguments = args => {
   const options = parseArgs(args, {
-    boolean: ['dry-run', 'ci'],
+    boolean: booleanOptions,
     alias: aliases,
     configuration: {
       'parse-numbers': false,

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,0 +1,64 @@
+import parseArgs from 'yargs-parser';
+
+const aliases = {
+  c: 'config',
+  d: 'dry-run',
+  h: 'help',
+  i: 'increment',
+  v: 'version',
+  V: 'verbose'
+};
+
+const booleanOptions = [
+  'dry-run',
+  'ci',
+  'git',
+  'npm',
+  'github',
+  'gitlab',
+  'git.addUntrackedFiles',
+  'git.requireCleanWorkingDir',
+  'git.requireUpstream',
+  'git.requireCommits',
+  'git.requireCommitsFail',
+  'git.commit',
+  'git.tag',
+  'git.push',
+  'git.getLatestTagFromAllRefs',
+  'git.skipChecks',
+  'github.release',
+  'github.autoGenerate',
+  'github.preRelease',
+  'github.draft',
+  'github.skipChecks',
+  'github.web',
+  'github.comments.submit',
+  'gitlab.release',
+  'gitlab.autoGenerate',
+  'gitlab.preRelease',
+  'gitlab.draft',
+  'gitlab.useIdsForUrls',
+  'gitlab.useGenericPackageRepositoryForAssets',
+  'gitlab.skipChecks',
+  'npm.publish',
+  'npm.ignoreVersion',
+  'npm.allowSameVersion',
+  'npm.skipChecks'
+];
+
+export const parseCliArguments = args => {
+  const options = parseArgs(args, {
+    boolean: booleanOptions,
+    alias: aliases,
+    configuration: {
+      'parse-numbers': false,
+      'camel-case-expansion': false
+    }
+  });
+  if (options.V) {
+    options.verbose = typeof options.V === 'boolean' ? options.V : options.V.length;
+    delete options.V;
+  }
+  options.increment = options._[0] || options.i;
+  return options;
+};

--- a/schema/git.json
+++ b/schema/git.json
@@ -53,6 +53,10 @@
       },
       "default": []
     },
+    "commitMessage": {
+      "type": "string",
+      "default": null
+    },
     "tag": {
       "type": "boolean",
       "default": true

--- a/test/args.js
+++ b/test/args.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCliArguments } from '../lib/args.js';
+
+test("should parse boolean arguments", () => {
+  const args = [
+    '--dry-run=false',
+    '--ci',
+    '--github=false',
+    '--no-npm',
+    '--git.addUntrackedFiles=true',
+    '--git.commit=false',
+    '--no-git.tag',
+    '--git.commitMessage=test',
+  ]
+
+  const result = parseCliArguments(args);
+
+  assert.equal(result['dry-run'], false);
+  assert.equal(result.ci, true);
+  assert.equal(result.github, false);
+  assert.equal(result.npm, false);
+  assert.equal(result.git.addUntrackedFiles, true);
+  assert.equal(result.git.commit, false);
+  assert.equal(result.git.tag, false);
+  assert.equal(result.git.commitMessage, 'test');
+});


### PR DESCRIPTION
Don't use "false" string as true value.

For example `release-it --git.commit=false` was parsed as `true`, because string `"false"` is non-empty.