### PR TITLE
fix: remove lodash

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,9 +4,9 @@ import { isCI } from 'ci-info';
 import defaultsDeep from '@nodeutils/defaults-deep';
 import { isObjectStrict } from '@phun-ky/typeof';
 import merge from 'lodash.merge';
-import get from 'lodash.get';
 import { loadConfig as loadC12 } from 'c12';
 import { getSystemInfo, readJSON } from './util.js';
+import { get } from './lodash.js';
 
 const debug = util.debug('release-it:config');
 const defaultConfig = readJSON(new URL('../config/release-it.json', import.meta.url));

--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -1,0 +1,9 @@
+export function get(obj, path) {
+  const keys = path.split('.');
+  let current = obj;
+  for (const key of keys) {
+    if (current[key] === undefined) return undefined;
+    current = current[key];
+  }
+  return current;
+}

--- a/lib/plugin/Plugin.js
+++ b/lib/plugin/Plugin.js
@@ -1,6 +1,6 @@
 import { debug } from 'node:util';
 import merge from 'lodash.merge';
-import get from 'lodash.get';
+import { get } from '../lodash';
 
 class Plugin {
   static isEnabled() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "git-url-parse": "16.1.0",
         "inquirer": "12.5.2",
         "issue-parser": "7.0.1",
-        "lodash.get": "4.4.2",
         "lodash.merge": "4.6.2",
         "mime-types": "3.0.1",
         "new-github-release-url": "2.0.0",
@@ -4171,13 +4170,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "git-url-parse": "16.1.0",
     "inquirer": "12.5.2",
     "issue-parser": "7.0.1",
-    "lodash.get": "4.4.2",
     "lodash.merge": "4.6.2",
     "mime-types": "3.0.1",
     "new-github-release-url": "2.0.0",


### PR DESCRIPTION
Looking at https://www.npmjs.com/package/lodash.get

![image](https://github.com/user-attachments/assets/9d5541d1-182e-4bfb-af80-6492dfc28efa)

I have spot that issue coming from a deprecation warning message by using release-it with pnpm.

