### PR TITLE
feat: add gitlab.repoId option

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -69,6 +69,7 @@
     "useGenericPackageRepositoryForAssets": false,
     "genericPackageRepositoryName": "release-it",
     "origin": null,
-    "skipChecks": false
+    "skipChecks": false,
+    "repoId": null
   }
 }

--- a/docs/gitlab-releases.md
+++ b/docs/gitlab-releases.md
@@ -28,6 +28,7 @@ GitLab Releases do not support pre-releases or drafts.
 | `gitlab.assets`                      | Glob pattern path to assets to add to the GitLab release                    |
 | `gitlab.origin`                      | Base URL to use for the GitLab API (default: `https://${repo.host}`)        |
 | `gitlab.skipChecks`                  | Skip checks on `GITLAB_TOKEN` environment variable and milestone(s)         |
+| `gitlab.repoId`                      | Useful when not possible to use namespaced paths in API requests.           |
 
 ## Prerequisite checks
 

--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -37,12 +37,12 @@ class GitLab extends Release {
   async init() {
     await super.init();
 
-    const { skipChecks, tokenRef, tokenHeader } = this.options;
+    const { skipChecks, tokenRef, tokenHeader, repoId } = this.options;
     const { repo } = this.getContext();
     const hasJobToken = (tokenHeader || '').toLowerCase() === 'job-token';
     const origin = this.options.origin || `https://${repo.host}`;
     this.setContext({
-      id: encodeURIComponent(repo.repository),
+      id: repoId !== undefined && repoId !== null ? String(repoId) : encodeURIComponent(repo.repository),
       origin,
       baseUrl: `${origin}/api/v4`
     });

--- a/schema/gitlab.json
+++ b/schema/gitlab.json
@@ -75,6 +75,10 @@
     "skipChecks": {
       "type": "boolean",
       "default": false
+    },
+    "repoId": {
+      "type": "string",
+      "default": null
     }
   }
 }

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -201,5 +201,8 @@ export interface Config {
 
     /** @default false */
     skipChecks?: boolean;
+
+    /** @default null */
+    repoId?: string;
   };
 }


### PR DESCRIPTION
This PR introduces a new release-it option `gitlab.repoId`.

## Summary
I've ran into an issue during when a `GitLab.isCollaborator` function was called. The request to 

```
RELEASE-IT:GITLAB 66: {
  url: 'https://mygitlab.com/api/v4/projects/namespace%2Fprojectname/members/all/22',
  method: 'GET'
}
RELEASE-IT:GITLAB 66: Error: 404 Not Found
ERROR User name is not a collaborator for ... .
```

returned 404, which release-it misinterpreted as an issue that a user is not a collaborator (which is not an issue here). I've found out the error is thrown because our current GitLab API instance does not support using namespaced paths in place of IDs. This can be the case for multiple reasons, e.g. different [server config](https://wiki.dongfg.com/base/gitlab-api-404.html) settings.

While I think the usually correct resolution is to fix the server settings, sometimes it's not really possible to adjust the server config ourselves (for whatever reason), which is why I needed to implement this PR to get release-it working for me. After I've specified `gitlab.repoId`, the request to Gitlab API finally went through fine and the release was made:)

Let me know if you think it's useful to merge, just wanted to create a PR in case it is:)

Thanks for good project!