### PR TITLE
fix: set octokit log option to {} instead of null

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -178,7 +178,7 @@ class GitHub extends Release {
       baseUrl,
       auth: `token ${this.token}`,
       userAgent: `release-it/${pkg.version}`,
-      log: this.config.isDebug ? console : null,
+      log: this.config.isDebug ? console : {},
       request: {
         timeout
       }


### PR DESCRIPTION
probably fixes:

* https://github.com/release-it/release-it/issues/1191
* https://github.com/release-it/release-it/issues/1238

side note: 

For some reason the octokit logger will not ~initialize~ default to `{}` when it's null

this is from `node_modules/@octokit/core/dist-src/index.js` 🤷 

```js
function createLogger(logger = {}) {
  if (typeof logger.debug !== "function") {
    logger.debug = noop;
  }
  if (typeof logger.info !== "function") {
    logger.info = noop;
  }
  if (typeof logger.warn !== "function") {
    logger.warn = consoleWarn;
  }
  if (typeof logger.error !== "function") {
    logger.error = consoleError;
  }
  return logger;
}
```