### PR TITLE
Add OIDC publishing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,26 +146,32 @@ remote.
 
 → See [Git][29] for more details.
 
+## npmjs.com Releases
+
+As of July 2025, GitHub and GitLab CI workflows can now use npm's [Trusted Publishing][30] OpenID Connect (OIDC)
+integration for secure, token-free publishing from CI/CD. This eliminates long-lived tokens and automatically generates
+provenance attestations. See [docs/npm.md][31] for details.
+
 ## GitHub Releases
 
 GitHub projects can have releases attached to Git tags, containing release notes and assets. There are two ways to add
-[GitHub releases][30] in your release-it flow:
+[GitHub releases][32] in your release-it flow:
 
 1. Automated (requires a `GITHUB_TOKEN`)
 2. Manual (using the GitHub web interface with pre-populated fields)
 
-→ See [GitHub Releases][31] for more details.
+→ See [GitHub Releases][33] for more details.
 
 ## GitLab Releases
 
 GitLab projects can have releases attached to Git tags, containing release notes and assets. To automate [GitLab
-releases][32]:
+releases][34]:
 
 - Configure `gitlab.release: true`
-- Obtain a [personal access token][33] (release-it needs the `api` and `self_rotate` scopes).
-- Make sure the token is [available as an environment variable][34].
+- Obtain a [personal access token][35] (release-it needs the `api` and `self_rotate` scopes).
+- Make sure the token is [available as an environment variable][36].
 
-→ See [GitLab Releases][35] for more details.
+→ See [GitLab Releases][37] for more details.
 
 ## Changelog
 
@@ -185,7 +191,7 @@ message conventions. Plugins are available for:
 
 To print the changelog without releasing anything, add the `--changelog` flag.
 
-→ See [Changelog][36] for more details.
+→ See [Changelog][38] for more details.
 
 ## Publish to npm
 
@@ -200,7 +206,7 @@ With release-it, it's easy to create pre-releases: a version of your software th
 it's not in the stable semver range yet. Often "alpha", "beta", and "rc" (release candidate) are used as identifiers for
 pre-releases. An example pre-release version is `2.0.0-beta.0`.
 
-→ See [Manage pre-releases][37] for more details.
+→ See [Manage pre-releases][39] for more details.
 
 ## Update or re-run existing releases
 
@@ -230,7 +236,7 @@ Use the optional `:plugin` part in the middle to hook into a life cycle method e
 The core plugins include `version`, `git`, `npm`, `github`, `gitlab`.
 
 Note that hooks like `after:git:release` will not run when either the `git push` failed, or when it is configured not to
-be executed (e.g. `git.push: false`). See [execution order][38] for more details on execution order of plugin lifecycle
+be executed (e.g. `git.push: false`). See [execution order][40] for more details on execution order of plugin lifecycle
 methods.
 
 All commands can use configuration variables (like template strings). An array of commands can also be provided, they
@@ -280,7 +286,7 @@ Using Inquirer.js inside custom hook scripts might cause issues (since release-i
 
 Use `--dry-run` to show the interactivity and the commands it _would_ execute.
 
-→ See [Dry Runs][39] for more details.
+→ See [Dry Runs][41] for more details.
 
 ## Troubleshooting & debugging
 
@@ -298,52 +304,52 @@ Since v11, release-it can be extended in many, many ways. Here are some plugins:
 | ----------------------------------------- | ------------------------------------------------------------------------------------------- |
 | [@release-it/bumper][26]                  | Read & write the version from/to any file                                                   |
 | [@release-it/conventional-changelog][27]  | Provides recommended bump, conventional-changelog, and updates `CHANGELOG.md`               |
-| [@release-it/keep-a-changelog][40]        | Maintain CHANGELOG.md using the Keep a Changelog standards                                  |
-| [@release-it-plugins/lerna-changelog][41] | Integrates lerna-changelog into the release-it pipeline                                     |
-| [@jcamp-code/release-it-changelogen][42]  | Use [@unjs/changelogen][43] for versioning and changelog                                    |
-| [@release-it-plugins/workspaces][44]      | Releases each of your projects configured workspaces                                        |
+| [@release-it/keep-a-changelog][42]        | Maintain CHANGELOG.md using the Keep a Changelog standards                                  |
+| [@release-it-plugins/lerna-changelog][43] | Integrates lerna-changelog into the release-it pipeline                                     |
+| [@jcamp-code/release-it-changelogen][44]  | Use [@unjs/changelogen][45] for versioning and changelog                                    |
+| [@release-it-plugins/workspaces][46]      | Releases each of your projects configured workspaces                                        |
 | [release-it-calver-plugin][28]            | Enables Calendar Versioning (calver) with release-it                                        |
-| [@grupoboticario/news-fragments][45]      | An easy way to generate your changelog file                                                 |
-| [@j-ulrich/release-it-regex-bumper][46]   | Regular expression based version read/write plugin for release-it                           |
-| [@jcamp-code/release-it-dotnet][47]       | Use .csproj or .props file for versioning, automate NuGet publishing                        |
-| [release-it-pnpm][16]                     | Add basic support for pnpm workspaces, integrates with [bumpp][48] and [changelogithub][49] |
-| [changesets-release-it-plugin][50]        | Combine [Changesets][51] changelog management with release-it                               |
-| [release-it-gitea][52]                    | Gitea plugin to create Gitea releases and upload attachments                                |
+| [@grupoboticario/news-fragments][47]      | An easy way to generate your changelog file                                                 |
+| [@j-ulrich/release-it-regex-bumper][48]   | Regular expression based version read/write plugin for release-it                           |
+| [@jcamp-code/release-it-dotnet][49]       | Use .csproj or .props file for versioning, automate NuGet publishing                        |
+| [release-it-pnpm][16]                     | Add basic support for pnpm workspaces, integrates with [bumpp][50] and [changelogithub][51] |
+| [changesets-release-it-plugin][52]        | Combine [Changesets][53] changelog management with release-it                               |
+| [release-it-gitea][54]                    | Gitea plugin to create Gitea releases and upload attachments                                |
 
 Internally, release-it uses its own plugin architecture (for Git, GitHub, GitLab, npm).
 
-→ See all [release-it plugins on npm][53].
+→ See all [release-it plugins on npm][55].
 
-→ See [plugins][54] for documentation to write plugins.
+→ See [plugins][56] for documentation to write plugins.
 
 ## Use release-it programmatically
 
 While mostly used as a CLI tool, release-it can be used as a dependency to integrate in your own scripts. See [use
-release-it programmatically][55] for example code.
+release-it programmatically][57] for example code.
 
 ## Projects using release-it
 
-- [AdonisJs][56]
-- [Axios][57]
-- [Cal.com][58]
-- [Ember CLI][59]
-- [Halo][60]
-- [hosts][61]
-- [js-cookie][62]
-- [jQuery][63]
-- [Madge][64]
-- [Metalsmith][65]
-- [Node-Redis][66]
-- [React Native Paper][67]
-- [Readability.js][68]
-- [Redux][69]
-- [Saleor][70]
-- [Semantic UI React][71]
-- [Shepherd][72]
-- [Tabler][73] + [tabler-icons][74]
-- Swagger ([swagger-ui][75] + [swagger-editor][76])
-- [Repositories that depend on release-it][77]
-- GitHub search for [path:\*\*/.release-it.json][78]
+- [AdonisJs][58]
+- [Axios][59]
+- [Cal.com][60]
+- [Ember CLI][61]
+- [Halo][62]
+- [hosts][63]
+- [js-cookie][64]
+- [jQuery][65]
+- [Madge][66]
+- [Metalsmith][67]
+- [Node-Redis][68]
+- [React Native Paper][69]
+- [Readability.js][70]
+- [Redux][71]
+- [Saleor][72]
+- [Semantic UI React][73]
+- [Shepherd][74]
+- [Tabler][75] + [tabler-icons][76]
+- Swagger ([swagger-ui][77] + [swagger-editor][78])
+- [Repositories that depend on release-it][79]
+- GitHub search for [path:\*\*/.release-it.json][80]
 
 ## Node.js version support
 
@@ -357,17 +363,17 @@ The latest major version is v19, supporting Node.js 20 and up:
 |    v16     |   v16   |
 |    v15     |   v14   |
 
-Also see [CHANGELOG.md][79] for dates and details.
+Also see [CHANGELOG.md][81] for dates and details.
 
 ## Links
 
-- See [CHANGELOG.md][79] for major/breaking updates, and [releases][80] for a detailed version history.
-- To **contribute**, please read [CONTRIBUTING.md][81] first.
-- Please [open an issue][82] if anything is missing or unclear in this documentation.
+- See [CHANGELOG.md][81] for major/breaking updates, and [releases][82] for a detailed version history.
+- To **contribute**, please read [CONTRIBUTING.md][83] first.
+- Please [open an issue][84] if anything is missing or unclear in this documentation.
 
 ## License
 
-[MIT][83]
+[MIT][85]
 
 Are you using release-it at work? Please consider [sponsoring me][14]!
 
@@ -400,57 +406,59 @@ Are you using release-it at work? Please consider [sponsoring me][14]!
 [27]: https://github.com/release-it/conventional-changelog
 [28]: https://github.com/casmith/release-it-calver-plugin
 [29]: ./docs/git.md
-[30]: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases
-[31]: ./docs/github-releases.md
-[32]: https://docs.gitlab.com/api/releases/
-[33]: https://gitlab.com/profile/personal_access_tokens
-[34]: ./docs/environment-variables.md
-[35]: ./docs/gitlab-releases.md
-[36]: ./docs/changelog.md
-[37]: ./docs/pre-releases.md
-[38]: ./docs/plugins.md#execution-order
-[39]: ./docs/dry-runs.md
-[40]: https://github.com/release-it/keep-a-changelog
-[41]: https://github.com/release-it-plugins/lerna-changelog
-[42]: https://github.com/jcamp-code/release-it-changelogen
-[43]: https://github.com/unjs/changelogen
-[44]: https://github.com/release-it-plugins/workspaces
-[45]: https://github.com/grupoboticario/news-fragments
-[46]: https://github.com/j-ulrich/release-it-regex-bumper
-[47]: https://github.com/jcamp-code/release-it-dotnet
-[48]: https://github.com/antfu/bumpp
-[49]: https://github.com/antfu/changelogithub
-[50]: https://www.npmjs.com/package/changesets-release-it-plugin
-[51]: https://github.com/changesets/changesets
-[52]: https://github.com/lib-pack/release-it-gitea
-[53]: https://www.npmjs.com/search?q=keywords:release-it-plugin
-[54]: ./docs/plugins.md
-[55]: ./docs/recipes/programmatic.md
-[56]: https://github.com/adonisjs/core
-[57]: https://github.com/axios/axios
-[58]: https://github.com/calcom/cal.com
-[59]: https://github.com/ember-cli/ember-cli
-[60]: https://github.com/halo-dev/halo
-[61]: https://github.com/StevenBlack/hosts
-[62]: https://github.com/js-cookie/js-cookie
-[63]: https://github.com/jquery/jquery
-[64]: https://github.com/pahen/madge
-[65]: https://github.com/metalsmith/metalsmith
-[66]: https://github.com/redis/node-redis
-[67]: https://github.com/callstack/react-native-paper
-[68]: https://github.com/mozilla/readability
-[69]: https://github.com/reduxjs/redux
-[70]: https://github.com/saleor/saleor
-[71]: https://github.com/Semantic-Org/Semantic-UI-React
-[72]: https://github.com/shipshapecode/shepherd
-[73]: https://github.com/tabler/tabler
-[74]: https://github.com/tabler/tabler-icons
-[75]: https://github.com/swagger-api/swagger-ui
-[76]: https://github.com/swagger-api/swagger-editor
-[77]: https://github.com/release-it/release-it/network/dependents
-[78]: https://github.com/search?q=path%3A**%2F.release-it.json&type=code
-[79]: ./CHANGELOG.md
-[80]: https://github.com/release-it/release-it/releases
-[81]: ./.github/CONTRIBUTING.md
-[82]: https://github.com/release-it/release-it/issues/new
-[83]: ./LICENSE
+[30]: https://docs.npmjs.com/trusted-publishers
+[31]: ./docs/npm.md#trusted-publishing-oidc
+[32]: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases
+[33]: ./docs/github-releases.md
+[34]: https://docs.gitlab.com/api/releases/
+[35]: https://gitlab.com/profile/personal_access_tokens
+[36]: ./docs/environment-variables.md
+[37]: ./docs/gitlab-releases.md
+[38]: ./docs/changelog.md
+[39]: ./docs/pre-releases.md
+[40]: ./docs/plugins.md#execution-order
+[41]: ./docs/dry-runs.md
+[42]: https://github.com/release-it/keep-a-changelog
+[43]: https://github.com/release-it-plugins/lerna-changelog
+[44]: https://github.com/jcamp-code/release-it-changelogen
+[45]: https://github.com/unjs/changelogen
+[46]: https://github.com/release-it-plugins/workspaces
+[47]: https://github.com/grupoboticario/news-fragments
+[48]: https://github.com/j-ulrich/release-it-regex-bumper
+[49]: https://github.com/jcamp-code/release-it-dotnet
+[50]: https://github.com/antfu/bumpp
+[51]: https://github.com/antfu/changelogithub
+[52]: https://www.npmjs.com/package/changesets-release-it-plugin
+[53]: https://github.com/changesets/changesets
+[54]: https://github.com/lib-pack/release-it-gitea
+[55]: https://www.npmjs.com/search?q=keywords:release-it-plugin
+[56]: ./docs/plugins.md
+[57]: ./docs/recipes/programmatic.md
+[58]: https://github.com/adonisjs/core
+[59]: https://github.com/axios/axios
+[60]: https://github.com/calcom/cal.com
+[61]: https://github.com/ember-cli/ember-cli
+[62]: https://github.com/halo-dev/halo
+[63]: https://github.com/StevenBlack/hosts
+[64]: https://github.com/js-cookie/js-cookie
+[65]: https://github.com/jquery/jquery
+[66]: https://github.com/pahen/madge
+[67]: https://github.com/metalsmith/metalsmith
+[68]: https://github.com/redis/node-redis
+[69]: https://github.com/callstack/react-native-paper
+[70]: https://github.com/mozilla/readability
+[71]: https://github.com/reduxjs/redux
+[72]: https://github.com/saleor/saleor
+[73]: https://github.com/Semantic-Org/Semantic-UI-React
+[74]: https://github.com/shipshapecode/shepherd
+[75]: https://github.com/tabler/tabler
+[76]: https://github.com/tabler/tabler-icons
+[77]: https://github.com/swagger-api/swagger-ui
+[78]: https://github.com/swagger-api/swagger-editor
+[79]: https://github.com/release-it/release-it/network/dependents
+[80]: https://github.com/search?q=path%3A**%2F.release-it.json&type=code
+[81]: ./CHANGELOG.md
+[82]: https://github.com/release-it/release-it/releases
+[83]: ./.github/CONTRIBUTING.md
+[84]: https://github.com/release-it/release-it/issues/new
+[85]: ./LICENSE

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -168,7 +168,8 @@ For Yarn workspaces, see the [release-it-yarn-workspaces][6] plugin.
 
 ## Trusted Publishing (OIDC)
 
-npm's [Trusted Publishing][10] uses OpenID Connect (OIDC) for secure, token-free publishing from CI/CD. This eliminates long-lived tokens and automatically generates provenance attestations.
+npm's [Trusted Publishing][7] uses OpenID Connect (OIDC) for secure, token-free publishing from CI/CD. This eliminates
+long-lived tokens and automatically generates provenance attestations.
 
 Note that none of these steps are optional.
 
@@ -180,7 +181,7 @@ Note that none of these steps are optional.
 
 ### Step 2: configure `release-it`
 
-When using Trusted Publishing, you **must** configure release-it to **skip npm authentication checks** (see [#1244][11]):
+When using Trusted Publishing, you **must** configure release-it to **skip npm authentication checks** (see [#1244][8]):
 
 ```json
 {
@@ -192,9 +193,9 @@ When using Trusted Publishing, you **must** configure release-it to **skip npm a
 
 ### Step 3: configure your publishing workflow
 
-You'll need to 
+You'll need to
 
-- add `id-token: write` and 
+- add `id-token: write` and
 - remove your `NODE_AUTH_TOKEN`
 - add a step to upgrade `npm` to at least v11.5.1
 
@@ -213,7 +214,7 @@ jobs:
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
-      
+
       # OIDC requires npm v11.5.1 or later
       # Node.js v20 comes with v10.8, so we need to update it:
       - run: npm install -g npm@latest
@@ -226,10 +227,10 @@ jobs:
 
 ## Miscellaneous
 
-- When `npm version` fails, the release is aborted (except when using [`--no-increment`][7]).
-- Learn how to [authenticate and publish from a CI/CD environment][8].
+- When `npm version` fails, the release is aborted (except when using [`--no-increment`][9]).
+- Learn how to [authenticate and publish from a CI/CD environment][10].
 - The `"private": true` setting in package.json will be respected, and `release-it` will skip this step.
-- Getting an `ENEEDAUTH` error while a manual `npm publish` works? Please see [#95][9].
+- Getting an `ENEEDAUTH` error while a manual `npm publish` works? Please see [#95][11].
 
 [1]: https://docs.npmjs.com/about-scopes
 [2]: https://registry.npmjs.org
@@ -237,8 +238,8 @@ jobs:
 [4]: https://github.com/release-it/bumper
 [5]: ./recipes/monorepo.md
 [6]: https://github.com/release-it-plugins/workspaces
-[7]: ../README.md#update-or-re-run-existing-releases
-[8]: ./ci.md#npm
-[9]: https://github.com/release-it/release-it/issues/95#issuecomment-344919384
-[10]: https://docs.npmjs.com/trusted-publishers
-[11]: https://github.com/release-it/release-it/issues/1244#issuecomment-3217898680
+[7]: https://docs.npmjs.com/trusted-publishers
+[8]: https://github.com/release-it/release-it/issues/1244#issuecomment-3217898680
+[9]: ../README.md#update-or-re-run-existing-releases
+[10]: ./ci.md#npm
+[11]: https://github.com/release-it/release-it/issues/95#issuecomment-344919384


### PR DESCRIPTION
Added new section to the npm docs describing how to get OIDC to work. Validated with https://github.com/photostructure/batch-cluster.js/actions/runs/17221702675/job/48859283308 (woot!)