### PR TITLE
fix: add shell mode for npm commands on windows

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -81,7 +81,9 @@ class Shell {
         };
         delete spawnOptions.interactive;
 
-        const proc = spawn(program, programArgs, spawnOptions);
+        const proc = process.platform === 'win32' && /^(npm|yarn|pnpm)$/.test(program)
+          ? spawn(command.join(' '), [], { ...spawnOptions, shell: true })
+          : spawn(program, programArgs, spawnOptions);
 
         let stdout = '';
         let stderr = '';


### PR DESCRIPTION
Closes #1265

### 🐛 Problem

On Windows, `npm` is not a native executable but a batch file (`npm.cmd`). When attempting to execute it directly without shell mode, the process fails because:

1. Windows cannot directly execute `.cmd` batch files without going through `cmd.exe`
2. The spawn function looks for an executable file and returns `ENOENT` when it can't find `npm` as a native executable

On Unix systems, `npm` is a shell script with a shebang (`#!/usr/bin/env node`), which can be executed directly, so the issue doesn't occur there.

### ✨ Changes

The fix adds detection logic to identify when running on Windows and determines if the command is a package manager (`npm`, `yarn` or `pnpm`) that requires shell execution.

The implementation adds conditional logic to enable `shell: true` in spawn options specifically for package managers on Windows. To avoid the Node.js deprecation warning `DEP0190`, the command array is converted to a string when using shell mode. Direct spawn is preserved for `git` and other native executables to maintain proper argument handling. This approach only uses shell mode when necessary (Windows and package managers), avoiding unnecessary overhead on Unix systems and for other commands. It maintains backward compatibility while preventing the deprecation warning, making it a minimal and targeted fix that doesn't affect the execution of other commands.