### PR TITLE
feat: add --quiet flag to hide release previews

### DIFF
--- a/config/release-it.json
+++ b/config/release-it.json
@@ -1,4 +1,5 @@
 {
+  "quiet": false,
   "hooks": {},
   "git": {
     "changelog": "git log --pretty=format:\"* %s (%h)\" ${from}...${to}",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,22 @@ commits since the latest tag.
 The [default command][1] is based on `git log ...`. This setting (`git.changelog`) can be overridden. Make sure any of
 these commands output the changelog to `stdout`.
 
+## Hide changelog preview
+
+For projects with very long changelogs, you can hide the changelog preview during the release preview to avoid flooding
+the console. This only affects the preview output during the normal release flow, not the `--changelog` mode which prints
+the changelog and exits.
+
+```json
+{
+  "logs": {
+    "preview": {
+      "changelog": "hide"
+    }
+  }
+}
+```
+
 - [GitHub and GitLab Releases][2]
 - [auto-changelog][3]
 - [Conventional Changelog][4]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,20 +6,22 @@ commits since the latest tag.
 The [default command][1] is based on `git log ...`. This setting (`git.changelog`) can be overridden. Make sure any of
 these commands output the changelog to `stdout`.
 
-## Hide changelog preview
+## Hide release preview output
 
-For projects with very long changelogs, you can hide the changelog preview during the release preview to avoid flooding
-the console. This only affects the preview output during the normal release flow, not the `--changelog` mode which prints
-the changelog and exits.
+For projects with very long changelogs or noisy diffs, you can suppress the preview blocks printed during the release
+flow (changelog, changeset, and release notes) to avoid flooding the console. A single notice is printed so it is clear
+that previews were hidden. This does not affect the `--changelog` mode, which prints the changelog and exits.
 
 ```json
 {
-  "logs": {
-    "preview": {
-      "changelog": "hide"
-    }
-  }
+  "quiet": true
 }
+```
+
+Or via the CLI:
+
+```bash
+release-it --quiet
 ```
 
 - [GitHub and GitLab Releases][2]

--- a/lib/args.js
+++ b/lib/args.js
@@ -12,6 +12,7 @@ const aliases = {
 const booleanOptions = [
   'dry-run',
   'ci',
+  'quiet',
   'git',
   'npm',
   'github',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,6 +18,7 @@ const helpText = `Release It! v${pkg.version}
   -v --version           Print release-it version number
      --release-version   Print version number to be released
      --changelog         Print changelog for the version to be released
+     --quiet             Suppress preview output during release
   -V --verbose           Verbose output (user hooks output)
   -VV                    Extra verbose output (also internal commands output)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -63,6 +63,10 @@ class Config {
     return debug.enabled;
   }
 
+  get isQuiet() {
+    return Boolean(this.options.quiet);
+  }
+
   get isCI() {
     return Boolean(this.options.ci) || this.isReleaseVersion || this.isChangelog;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,10 @@ const runTasks = async (opts, di) => {
       const action = config.isIncrement ? 'release' : 'update';
       const suffix = version && config.isIncrement ? `${latestVersion}...${version}` : `currently at ${latestVersion}`;
       log.obtrusive(`🚀 Let's ${action} ${name} (${suffix})`);
-      log.preview({ title: 'changelog', text: changelog });
+      const mode = options?.logs?.preview?.changelog ?? 'show';
+      if (mode !== 'hide') {
+        log.preview({ title: 'changelog', text: changelog });
+      }
     }
 
     if (config.isIncrement) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,9 @@ const runTasks = async (opts, di) => {
     await container.config.init();
 
     const { config } = container;
-    const { isCI, isVerbose, verbosityLevel, isDryRun, isChangelog, isReleaseVersion } = config;
+    const { isCI, isVerbose, verbosityLevel, isDryRun, isChangelog, isReleaseVersion, isQuiet } = config;
 
-    container.log = container.log || new Logger({ isCI, isVerbose, verbosityLevel, isDryRun });
+    container.log = container.log || new Logger({ isCI, isVerbose, verbosityLevel, isDryRun, isQuiet });
     container.spinner = container.spinner || new Spinner({ container, config });
     container.prompt = container.prompt || new Prompt({ container: { config } });
     container.shell = container.shell || new Shell({ container });
@@ -94,10 +94,8 @@ const runTasks = async (opts, di) => {
       const action = config.isIncrement ? 'release' : 'update';
       const suffix = version && config.isIncrement ? `${latestVersion}...${version}` : `currently at ${latestVersion}`;
       log.obtrusive(`🚀 Let's ${action} ${name} (${suffix})`);
-      const mode = options?.logs?.preview?.changelog ?? 'show';
-      if (mode !== 'hide') {
-        log.preview({ title: 'changelog', text: changelog });
-      }
+      if (isQuiet) log.info('Preview output hidden (--quiet).');
+      log.preview({ title: 'changelog', text: changelog });
     }
 
     if (config.isIncrement) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -4,11 +4,12 @@ import { isObjectLoose } from '@phun-ky/typeof';
 import { upperFirst } from './util.js';
 
 class Logger {
-  constructor({ isCI = true, isVerbose = false, verbosityLevel = 0, isDryRun = false } = {}) {
+  constructor({ isCI = true, isVerbose = false, verbosityLevel = 0, isDryRun = false, isQuiet = false } = {}) {
     this.isCI = isCI;
     this.isVerbose = isVerbose;
     this.verbosityLevel = verbosityLevel;
     this.isDryRun = isDryRun;
+    this.isQuiet = isQuiet;
   }
 
   shouldLog(isExternal) {
@@ -57,6 +58,7 @@ class Logger {
   }
 
   preview({ title, text }) {
+    if (this.isQuiet) return;
     if (text) {
       const header = styleText('bold', upperFirst(title));
       const body = text.replace(new RegExp(EOL + EOL, 'g'), EOL);

--- a/schema/release-it.json
+++ b/schema/release-it.json
@@ -88,6 +88,24 @@
         "type": "boolean",
         "default": false
       }
+    },
+    "logs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preview": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "changelog": {
+              "type": "string",
+              "enum": ["show", "hide"],
+              "default": "show",
+              "description": "Control whether the changelog preview is shown during release preview. Only affects the preview output, not the --changelog mode."
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/schema/release-it.json
+++ b/schema/release-it.json
@@ -89,23 +89,10 @@
         "default": false
       }
     },
-    "logs": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "preview": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "changelog": {
-              "type": "string",
-              "enum": ["show", "hide"],
-              "default": "show",
-              "description": "Control whether the changelog preview is shown during release preview. Only affects the preview output, not the --changelog mode."
-            }
-          }
-        }
-      }
+    "quiet": {
+      "type": "boolean",
+      "default": false,
+      "description": "Suppress preview output (changelog, changeset, release notes) during the release flow. Does not affect the --changelog mode."
     }
   }
 }

--- a/test/log.js
+++ b/test/log.js
@@ -143,4 +143,22 @@ describe('log', () => {
     const { stdout } = mockStdIo.end();
     assert.equal(stripVTControlCharacters(stdout), `Title:${EOL}changelog\n`);
   });
+
+  test('should print preview when not quiet', () => {
+    const log = new Log({ isQuiet: false });
+    mockStdIo.start();
+    log.preview({ title: 'changelog', text: 'x' });
+    const { stdout } = mockStdIo.end();
+    assert.notEqual(stdout, '');
+  });
+
+  test('should suppress every preview when quiet', () => {
+    const log = new Log({ isQuiet: true });
+    mockStdIo.start();
+    log.preview({ title: 'changelog', text: 'x' });
+    log.preview({ title: 'changeset', text: 'y' });
+    log.preview({ title: 'release notes', text: 'z' });
+    const { stdout } = mockStdIo.end();
+    assert.equal(stdout, '');
+  });
 });

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -575,4 +575,50 @@ describe('tasks', () => {
       'echo after:afterRelease'
     ]);
   });
+
+  test('should show changelog preview by default', async () => {
+    gitAdd('{"name":"my-package","version":"1.2.3"}', 'package.json', 'Add package.json');
+    childProcess.execSync('git tag 1.2.3', execOpts);
+    gitAdd('line', 'file', 'Add file');
+    await runTasks(
+      {},
+      getContainer({
+        increment: 'patch'
+      })
+    );
+    const changelogCalls = log.preview.mock.calls.filter(call => call.arguments[0].title === 'changelog');
+    assert.equal(changelogCalls.length, 1);
+    assert(changelogCalls[0].arguments[0].text.includes('Add file'));
+  });
+
+  test('should show changelog preview when logs.preview.changelog is "show"', async () => {
+    gitAdd('{"name":"my-package","version":"1.2.3"}', 'package.json', 'Add package.json');
+    childProcess.execSync('git tag 1.2.3', execOpts);
+    gitAdd('line', 'file', 'Add file');
+    await runTasks(
+      {},
+      getContainer({
+        increment: 'patch',
+        logs: { preview: { changelog: 'show' } }
+      })
+    );
+    const changelogCalls = log.preview.mock.calls.filter(call => call.arguments[0].title === 'changelog');
+    assert.equal(changelogCalls.length, 1);
+  });
+
+  test('should hide changelog preview when logs.preview.changelog is "hide"', async () => {
+    gitAdd('{"name":"my-package","version":"1.2.3"}', 'package.json', 'Add package.json');
+    childProcess.execSync('git tag 1.2.3', execOpts);
+    gitAdd('line', 'file', 'Add file');
+    await runTasks(
+      {},
+      getContainer({
+        increment: 'patch',
+        logs: { preview: { changelog: 'hide' } }
+      })
+    );
+    assert(log.obtrusive.mock.calls[0].arguments[0].includes('release my-package'));
+    const changelogCalls = log.preview.mock.calls.filter(call => call.arguments[0].title === 'changelog');
+    assert.equal(changelogCalls.length, 0);
+  });
 });

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -591,7 +591,7 @@ describe('tasks', () => {
     assert(changelogCalls[0].arguments[0].text.includes('Add file'));
   });
 
-  test('should show changelog preview when logs.preview.changelog is "show"', async () => {
+  test('should show changelog preview when quiet is false', async () => {
     gitAdd('{"name":"my-package","version":"1.2.3"}', 'package.json', 'Add package.json');
     childProcess.execSync('git tag 1.2.3', execOpts);
     gitAdd('line', 'file', 'Add file');
@@ -599,14 +599,14 @@ describe('tasks', () => {
       {},
       getContainer({
         increment: 'patch',
-        logs: { preview: { changelog: 'show' } }
+        quiet: false
       })
     );
     const changelogCalls = log.preview.mock.calls.filter(call => call.arguments[0].title === 'changelog');
     assert.equal(changelogCalls.length, 1);
   });
 
-  test('should hide changelog preview when logs.preview.changelog is "hide"', async () => {
+  test('should announce hidden preview when quiet is true', async () => {
     gitAdd('{"name":"my-package","version":"1.2.3"}', 'package.json', 'Add package.json');
     childProcess.execSync('git tag 1.2.3', execOpts);
     gitAdd('line', 'file', 'Add file');
@@ -614,11 +614,10 @@ describe('tasks', () => {
       {},
       getContainer({
         increment: 'patch',
-        logs: { preview: { changelog: 'hide' } }
+        quiet: true
       })
     );
     assert(log.obtrusive.mock.calls[0].arguments[0].includes('release my-package'));
-    const changelogCalls = log.preview.mock.calls.filter(call => call.arguments[0].title === 'changelog');
-    assert.equal(changelogCalls.length, 0);
+    assert(log.info.mock.calls.some(call => call.arguments[0] === 'Preview output hidden (--quiet).'));
   });
 });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -205,4 +205,11 @@ export interface Config {
     /** @default false */
     skipChecks?: boolean;
   };
+
+  logs?: {
+    preview?: {
+      /** @default "show" */
+      changelog?: 'show' | 'hide';
+    };
+  };
 }

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -206,10 +206,6 @@ export interface Config {
     skipChecks?: boolean;
   };
 
-  logs?: {
-    preview?: {
-      /** @default "show" */
-      changelog?: 'show' | 'hide';
-    };
-  };
+  /** @default false */
+  quiet?: boolean;
 }


### PR DESCRIPTION
#1258 closed

## Description

This PR introduces a `quiet` flag that suppresses the preview blocks printed during the release process.

Previously, release-it would print the full changelog (and, via the same `Logger.preview()` call, the changeset and release notes) during the preview phase, which could flood the console for projects with long changelogs or noisy diffs.
With this change, users can suppress that preview output while keeping the `--changelog` behavior unchanged.

## Changes

- **New top-level option** `quiet` (boolean, default `false`) with matching CLI flag `--quiet`.
  The name mirrors the conventional meaning in other CLIs (e.g., `git --quiet`, `npm --quiet`) and keeps the config surface flat rather than introducing a new nested namespace.
- **Logger-level guard**: `Logger.preview()` now short-circuits when `isQuiet` is set. This covers all three preview callsites — changelog (`lib/index.js`), changeset (`lib/plugin/git/Git.js`), and release notes (`lib/plugin/GitRelease.js`) — so the flag name matches its scope.
- **User-visible notice**: When `quiet` is active, a single `Preview output hidden (--quiet).` line is logged right after the "Let's release ..." banner, so suppression is never silent.
- **CLI parser**: `quiet` added to `booleanOptions` in `lib/args.js` so `--quiet` / `--no-quiet` parse as proper booleans.
- **Schema update**: `schema/release-it.json` adds a top-level `quiet: boolean` (default `false`) with a description covering all three previews. `additionalProperties: false` preserved.
- **Type update**: `types/config.d.ts` adds `quiet?: boolean`.
- **Default config**: `config/release-it.json` sets `quiet: false`.
- **Docs**: `docs/changelog.md` section updated to cover the new flag and scope.
- **Tests**:
  - `test/log.js` — unit tests assert that all three preview titles are suppressed when `isQuiet: true`, and still rendered when `false`.
  - `test/tasks.js` — integration tests cover default behavior, `quiet: false`, and `quiet: true` (including the info notice).

## Motivation

- **Reduce console noise**: Long changelogs and diffs make it hard to focus on the important release output and can push the confirmation prompt off-screen.
- **Keep existing workflows**: Users who rely on `--changelog` see no behavior changes — that code path exits before the preview block.
- **Honest naming**: A flag called `quiet` should affect all preview output, not just one block. A Logger-level guard keeps the name and the scope aligned.

## Breaking Changes

None for released versions.
Default remains `false`, preserving current output behavior.
`--changelog` mode is untouched.

> Note: this PR replaces an earlier unreleased `logs.preview.changelog` nested option (from previous commits on this branch) with the simpler top-level `quiet` flag. No user-facing breakage since that shape never shipped.