### PR TITLE
refactor: Continuing my previous refactor work to remove lodash

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 import util from 'node:util';
 import assert from 'node:assert';
 import { isCI } from 'ci-info';
-import defaultsDeep from '@nodeutils/defaults-deep';
+import defaultsDeep from '@phun-ky/defaults-deep';
 import { isObjectStrict } from '@phun-ky/typeof';
 import merge from 'lodash.merge';
 import { loadConfig as loadC12 } from 'c12';

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
+        "@phun-ky/defaults-deep": "1.1.2",
         "@phun-ky/typeof": "2.0.3",
         "async-retry": "1.3.3",
         "c12": "3.3.3",
@@ -720,16 +720,20 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -768,15 +772,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@nodeutils/defaults-deep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
-      "integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.15.0"
       }
     },
     "node_modules/@npmcli/config": {
@@ -1359,19 +1354,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz",
-      "integrity": "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      }
-    },
     "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
       "version": "11.16.0",
       "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.16.0.tgz",
@@ -1413,6 +1395,35 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@phun-ky/defaults-deep": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@phun-ky/defaults-deep/-/defaults-deep-1.1.2.tgz",
+      "integrity": "sha512-UqfUyg4DxuSXag2vEP2ABsCbZKURTLn++CAvE/xE2MVPIaElxnPdhFNAQ+E2Kg3ri2U4oCau9uGbAuMrIN9F9w==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@phun-ky/typeof": "^2.1.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22.0.0",
+        "npm": ">=10.8.2"
+      },
+      "funding": {
+        "url": "https://github.com/phun-ky/defaults-deep?sponsor=1"
+      }
+    },
+    "node_modules/@phun-ky/defaults-deep/node_modules/@phun-ky/typeof": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@phun-ky/typeof/-/typeof-2.1.0.tgz",
+      "integrity": "sha512-mAGTXdP6gLnUpL/eybwHudjtF9zAKOY49ddILo+bVPvTqDHAYEPvLjbLo3UEHJqwyWlpoaaA2Ph+KpvrblYNow==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.9.0 || >=22.0.0",
+        "npm": ">=10.8.2"
+      },
+      "funding": {
+        "url": "https://github.com/phun-ky/typeof?sponsor=1"
+      }
     },
     "node_modules/@phun-ky/typeof": {
       "version": "2.0.3",
@@ -1819,6 +1830,19 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -4064,12 +4088,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@nodeutils/defaults-deep": "1.1.0",
     "@octokit/rest": "22.0.1",
+    "@phun-ky/defaults-deep": "1.1.2",
     "@phun-ky/typeof": "2.0.3",
     "async-retry": "1.3.3",
     "c12": "3.3.3",


### PR DESCRIPTION
This is not meant to be a "replace anything with my own packages", but rather a quest to get rid of `lodash` and find smaller, preferably vanilla, alternatives.

I could not find any decent alternatives, and `@node-utils/defaults-deep` (which I added back in the days) still had `lodash` as a dependency. This is now removed.

Next up is `issue-parser`.