### PR TITLE
Fix `Logger.info()` on Node.js 25

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -24,7 +24,7 @@ class Logger {
   }
 
   info(...args) {
-    console.error(styleText('grey', args.join(' ')));
+    console.error(styleText('gray', args.join(' ')));
   }
 
   warn(...args) {

--- a/test/log.js
+++ b/test/log.js
@@ -24,6 +24,14 @@ describe('log', () => {
     assert.equal(stripVTControlCharacters(stderr), 'ERROR foo\n');
   });
 
+  test('should print info', () => {
+    const log = new Log();
+    mockStdIo.start();
+    log.info('foo');
+    const { stderr } = mockStdIo.end();
+    assert.equal(stripVTControlCharacters(stderr), 'foo\n');
+  });
+
   test('should print a warning', () => {
     const log = new Log();
     mockStdIo.start();


### PR DESCRIPTION
Fix #1283

## Description

When running release-it on Node.js **25**. Any call to function `Logger.info()` fails with the following exception:

> ```TypeError [ERR_INVALID_ARG_VALUE]: The argument 'format' must be one of: 'reset', 'bold', 'dim', 'italic', 'underline', 'blink', 'inverse', 'hidden', 'strikethrough', 'doubleunderline', 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'bgBlack', 'bgRed', 'bgGreen', 'bgYellow', 'bgBlue', 'bgMagenta', 'bgCyan', 'bgWhite', 'framed', 'overlined', 'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', 'cyanBright', 'whiteBright', 'bgGray', 'bgRedBright', 'bgGreenBright', 'bgYellowBright', 'bgBlueBright', 'bgMagentaBright', 'bgCyanBright', 'bgWhiteBright'. Received 'grey'```

This looks like a Node.js bug, maybe related to this change: https://github.com/nodejs/node/pull/61792

## Change

Use the actual color name `'gray'` instead of alias `'grey'`.

Related: https://nodejs.org/api/util.html#customizing-utilinspect-colors