### PR TITLE
fix: remove leading slashes from owner

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -95,7 +95,7 @@ export const parseGitUrl = remoteUrl => {
     .replace(/\\+/g, '/'); // Replace forward with backslashes
   const parsedUrl = gitUrlParse(normalizedUrl);
   const { resource: host, name: project, protocol, href: remote } = parsedUrl;
-  const owner = protocol === 'file' ? parsedUrl.owner.split('/').at(-1) : parsedUrl.owner; // Fix owner for file protocol
+  const owner = protocol === 'file' ? parsedUrl.owner.split('/').at(-1) : parsedUrl.owner?.replace(/^\/+/, ''); // Fix owner for file protocol
   const repository = `${owner}/${project}`;
   return { host, owner, project, protocol, remote, repository };
 };


### PR DESCRIPTION
Git URLs with leading slash after the protocol colon are parsed incorrectly:

```bash
git@github.com:/ORG/REPO.git  # incorrect
git@github.com:ORG/REPO.git   # correct
```