### PR TITLE
fix: allow false as npm config value in types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -99,7 +99,7 @@ export interface Config {
 
     /** @default 10 */
     timeout?: number;
-  };
+  } | false;
 
   github?: {
     /** @default false */


### PR DESCRIPTION
`false` is a valid value to disable publishing to npm, see https://github.com/release-it/release-it/blob/main/docs/npm.md?plain=1#L7

The current types do not allow `false` as value.