### PR TITLE
semconv: replace custom git attrs with OTel VCS equivalents

### DIFF
--- a/examples/instrumentation.js
+++ b/examples/instrumentation.js
@@ -1,0 +1,51 @@
+// ABOUTME: OTel SDK bootstrap — loaded via Node.js --import flag before application code
+// ABOUTME: Configures tracing with OTLP HTTP exporter for local Datadog Agent on port 4318
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+
+// Disable auto-metrics — SDK 2.x auto-instantiates a Metrics SDK.
+// For IS scoring runs: set IS_SCORING_RUN=1 to enable the metrics exporter so
+// MET rules can be evaluated.
+if (!process.env.OTEL_METRICS_EXPORTER && !process.env.IS_SCORING_RUN) {
+  process.env.OTEL_METRICS_EXPORTER = 'none';
+}
+
+const traceExporter = new OTLPTraceExporter({
+  url: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || 'http://localhost:4318/v1/traces',
+});
+
+const sdk = new NodeSDK({
+  resource: resourceFromAttributes({
+    'service.name': 'release-it',
+    'service.version': pkg.version,
+    'deployment.environment': process.env.NODE_ENV || 'development',
+  }),
+  // SimpleSpanProcessor exports each span immediately on span.end() — better
+  // for CLI apps where process.exit() can kill the event loop before a
+  // BatchSpanProcessor flushes.
+  spanProcessors: [new SimpleSpanProcessor(traceExporter)],
+});
+
+sdk.start();
+
+// Graceful shutdown — flush pending spans before exit.
+// SIGTERM uses 143 (128 + SIGTERM signal number 15).
+// SIGINT uses 130 (128 + SIGINT signal number 2).
+process.on('SIGTERM', async () => {
+  await sdk.shutdown().catch((err) => console.error('OTel SDK shutdown error:', err));
+  process.exit(143);
+});
+
+process.on('SIGINT', async () => {
+  await sdk.shutdown().catch((err) => console.error('OTel SDK shutdown error:', err));
+  process.exit(130);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,14 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,14 @@
     "tar": "7.5.13",
     "typescript": "6.0.2"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
+  },
   "overrides": {
     "pac-resolver": "7.0.1",
     "socks": "2.8.3",

--- a/semconv/attributes.yaml
+++ b/semconv/attributes.yaml
@@ -120,13 +120,9 @@ groups:
           - "Release 20.0.0"
           - "chore: release v20.0.0"
 
-      - id: release_it.git.remote_url
-        type: string
-        stability: development
-        brief: The remote URL of the git repository
-        examples:
-          - "https://github.com/release-it/release-it"
-          - "git@github.com:release-it/release-it.git"
+      # Use OTel VCS semconv for repository URL and branch name
+      - ref: vcs.repository.url.full
+        brief: The remote URL of the git repository being released
 
       - id: release_it.git.commits_since_tag
         type: int
@@ -136,13 +132,9 @@ groups:
           - 12
           - 1
 
-      - id: release_it.git.branch
-        type: string
-        stability: development
-        brief: The current git branch name
-        examples:
-          - "main"
-          - "master"
+      # Use OTel VCS semconv for branch name
+      - ref: vcs.ref.head.name
+        brief: The git branch being released from
 
   # ==========================================================================
   # CHANGELOG ATTRIBUTES

--- a/semconv/attributes.yaml
+++ b/semconv/attributes.yaml
@@ -1,0 +1,318 @@
+# release-it Attribute Definitions
+# Custom attributes for release-it release automation operations
+
+groups:
+  # ==========================================================================
+  # VERSION ATTRIBUTES
+  # Describes version determination and bumping operations
+  # ==========================================================================
+  - id: registry.release_it.version
+    type: attribute_group
+    display_name: Version Attributes
+    brief: Attributes describing version bumping and increment operations
+    attributes:
+      - id: release_it.version.current
+        type: string
+        stability: development
+        brief: The current/latest version before this release
+        examples:
+          - "19.7.5"
+          - "0.0.0"
+
+      - id: release_it.version.next
+        type: string
+        stability: development
+        brief: The new version being released
+        examples:
+          - "20.0.0"
+          - "19.8.0"
+          - "19.7.6"
+
+      - id: release_it.version.increment
+        type:
+          members:
+            - id: patch
+              value: patch
+              brief: Patch version increment (bug fixes)
+              stability: development
+            - id: minor
+              value: minor
+              brief: Minor version increment (new features)
+              stability: development
+            - id: major
+              value: major
+              brief: Major version increment (breaking changes)
+              stability: development
+            - id: prepatch
+              value: prepatch
+              brief: Pre-release patch increment
+              stability: development
+            - id: preminor
+              value: preminor
+              brief: Pre-release minor increment
+              stability: development
+            - id: premajor
+              value: premajor
+              brief: Pre-release major increment
+              stability: development
+            - id: prerelease
+              value: prerelease
+              brief: Pre-release continuation increment
+              stability: development
+        stability: development
+        brief: The type of version increment performed
+
+  # ==========================================================================
+  # RELEASE ATTRIBUTES
+  # Top-level release run configuration
+  # ==========================================================================
+  - id: registry.release_it.release
+    type: attribute_group
+    display_name: Release Attributes
+    brief: Attributes describing the overall release operation
+    attributes:
+      - id: release_it.is_dry_run
+        type: boolean
+        stability: development
+        brief: Whether the release ran in dry-run mode (no writes)
+        examples:
+          - true
+          - false
+
+      - id: release_it.is_ci
+        type: boolean
+        stability: development
+        brief: Whether the release ran in CI mode (non-interactive)
+        examples:
+          - true
+          - false
+
+      - id: release_it.package_name
+        type: string
+        stability: development
+        brief: The name of the package or project being released
+        examples:
+          - "release-it"
+          - "my-library"
+
+  # ==========================================================================
+  # GIT ATTRIBUTES
+  # Describes git operations performed during release
+  # ==========================================================================
+  - id: registry.release_it.git
+    type: attribute_group
+    display_name: Git Attributes
+    brief: Attributes for git commit, tag, and push operations
+    attributes:
+      - id: release_it.git.tag_name
+        type: string
+        stability: development
+        brief: The git tag name created for this release
+        examples:
+          - "v20.0.0"
+          - "20.0.0"
+
+      - id: release_it.git.commit_message
+        type: string
+        stability: development
+        brief: The commit message used for the release commit
+        examples:
+          - "Release 20.0.0"
+          - "chore: release v20.0.0"
+
+      - id: release_it.git.remote_url
+        type: string
+        stability: development
+        brief: The remote URL of the git repository
+        examples:
+          - "https://github.com/release-it/release-it"
+          - "git@github.com:release-it/release-it.git"
+
+      - id: release_it.git.commits_since_tag
+        type: int
+        stability: development
+        brief: Number of commits since the last release tag
+        examples:
+          - 12
+          - 1
+
+      - id: release_it.git.branch
+        type: string
+        stability: development
+        brief: The current git branch name
+        examples:
+          - "main"
+          - "master"
+
+  # ==========================================================================
+  # CHANGELOG ATTRIBUTES
+  # Describes changelog generation
+  # ==========================================================================
+  - id: registry.release_it.changelog
+    type: attribute_group
+    display_name: Changelog Attributes
+    brief: Attributes for changelog generation operations
+    attributes:
+      - id: release_it.changelog.length
+        type: int
+        stability: development
+        brief: Character length of the generated changelog text
+        examples:
+          - 1240
+          - 342
+
+  # ==========================================================================
+  # GITHUB RELEASE ATTRIBUTES
+  # Describes GitHub release creation via Octokit
+  # ==========================================================================
+  - id: registry.release_it.github
+    type: attribute_group
+    display_name: GitHub Release Attributes
+    brief: Attributes for GitHub release creation operations
+    attributes:
+      - id: release_it.github.owner
+        type: string
+        stability: development
+        brief: The GitHub repository owner (user or organization)
+        examples:
+          - "release-it"
+          - "wiggitywhitney"
+
+      - id: release_it.github.repository
+        type: string
+        stability: development
+        brief: The GitHub repository name
+        examples:
+          - "release-it"
+          - "my-project"
+
+      - id: release_it.github.release_id
+        type: int
+        stability: development
+        brief: The ID of the created GitHub release
+        examples:
+          - 123456789
+
+      - id: release_it.github.draft
+        type: boolean
+        stability: development
+        brief: Whether the GitHub release was created as a draft
+        examples:
+          - false
+          - true
+
+      - id: release_it.github.prerelease
+        type: boolean
+        stability: development
+        brief: Whether the GitHub release is marked as a pre-release
+        examples:
+          - false
+          - true
+
+      - id: release_it.github.assets_count
+        type: int
+        stability: development
+        brief: Number of asset files uploaded to the GitHub release
+        examples:
+          - 0
+          - 3
+
+  # ==========================================================================
+  # NPM PUBLISH ATTRIBUTES
+  # Describes npm package publishing
+  # ==========================================================================
+  - id: registry.release_it.npm
+    type: attribute_group
+    display_name: npm Publish Attributes
+    brief: Attributes for npm package publication operations
+    attributes:
+      - id: release_it.npm.package_name
+        type: string
+        stability: development
+        brief: The npm package name being published
+        examples:
+          - "release-it"
+          - "@myorg/my-package"
+
+      - id: release_it.npm.dist_tag
+        type: string
+        stability: development
+        brief: The npm distribution tag applied to this publish
+        examples:
+          - "latest"
+          - "next"
+          - "beta"
+
+      - id: release_it.npm.registry
+        type: string
+        stability: development
+        brief: The npm registry URL used for publishing
+        examples:
+          - "https://registry.npmjs.org"
+          - "https://npm.pkg.github.com"
+
+  # ==========================================================================
+  # PLUGIN ATTRIBUTES
+  # Describes plugin lifecycle execution
+  # ==========================================================================
+  - id: registry.release_it.plugin
+    type: attribute_group
+    display_name: Plugin Attributes
+    brief: Attributes for release-it plugin lifecycle operations
+    attributes:
+      - id: release_it.plugin.namespace
+        type: string
+        stability: development
+        brief: The namespace identifier for the plugin
+        examples:
+          - "git"
+          - "github"
+          - "npm"
+          - "version"
+
+      - id: release_it.plugin.hook
+        type: string
+        stability: development
+        brief: The lifecycle hook name being executed
+        examples:
+          - "init"
+          - "beforeBump"
+          - "bump"
+          - "beforeRelease"
+          - "release"
+          - "afterRelease"
+
+  # ==========================================================================
+  # HOOK ATTRIBUTES
+  # Describes user-defined lifecycle hook script execution
+  # ==========================================================================
+  - id: registry.release_it.hook
+    type: attribute_group
+    display_name: Hook Script Attributes
+    brief: Attributes for user-defined hook script execution
+    attributes:
+      - id: release_it.hook.name
+        type: string
+        stability: development
+        brief: The lifecycle event name that triggered this hook
+        examples:
+          - "before:git:tag"
+          - "after:git:push"
+          - "before:release"
+          - "after:release"
+
+      - id: release_it.hook.command
+        type: string
+        stability: development
+        brief: The shell command executed by the hook
+        examples:
+          - "npm run build"
+          - "echo \"Releasing ${version}\""
+
+      - id: release_it.hook.exit_code
+        type: int
+        stability: development
+        brief: Exit code returned by the hook script
+        examples:
+          - 0
+          - 1

--- a/semconv/registry_manifest.yaml
+++ b/semconv/registry_manifest.yaml
@@ -1,0 +1,12 @@
+# release-it Telemetry Registry
+# OpenTelemetry Weaver schema for release-it semantic versioning and release automation
+
+name: release_it
+description: OpenTelemetry semantic conventions for release-it release automation tool
+semconv_version: 0.1.0
+
+schema_base_url: https://release-it.dev/schemas/
+
+dependencies:
+  - name: otel
+    registry_path: https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.37.0.zip[model]

--- a/spiny-orb.yaml
+++ b/spiny-orb.yaml
@@ -1,0 +1,3 @@
+schemaPath: semconv
+sdkInitFile: examples/instrumentation.js
+dependencyStrategy: peerDependencies


### PR DESCRIPTION
## Summary

- Replaces `release_it.git.remote_url` with `ref: vcs.repository.url.full` (OTel semconv v1.40.0)
- Replaces `release_it.git.branch` with `ref: vcs.ref.head.name` (OTel semconv v1.40.0)
- Remaining git attributes (`tag_name`, `commit_message`, `commits_since_tag`) have no semconv equivalents and remain as custom attributes

## Context

Audit of the release-it Weaver registry against OTel semantic conventions v1.40.0 identified two custom attributes that duplicate existing semconv VCS attributes. Using the standard attributes prevents divergence from the specification. The commit-story-v2 registry already uses `vcs.ref.head.name` correctly; this brings release-it into alignment.

Closes wiggitywhitney/spinybacked-orbweaver-eval#67

## Test plan

- [x] `release_it.git.remote_url` replaced with `ref: vcs.repository.url.full`
- [x] `release_it.git.branch` replaced with `ref: vcs.ref.head.name`
- [x] All other attributes unchanged
- [ ] CodeRabbit review addressed