### PR TITLE
fix: Replace @nodeutils/defaults-deep with defu for deep-default merging

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 import util from 'node:util';
 import assert from 'node:assert';
 import { isCI } from 'ci-info';
-import defaultsDeep from '@nodeutils/defaults-deep';
+import defu from 'defu';
 import { isObjectStrict } from '@phun-ky/typeof';
 import merge from 'lodash.merge';
 import { loadConfig as loadC12 } from 'c12';
@@ -92,7 +92,7 @@ class Config {
 
 async function loadOptions(constructorConfig) {
   const localConfig = await loadLocalConfig(constructorConfig);
-  const merged = defaultsDeep(
+  const merged = defu(
     {},
     constructorConfig,
     {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 import util from 'node:util';
 import assert from 'node:assert';
 import { isCI } from 'ci-info';
-import defu from 'defu';
+import { createDefu } from 'defu';
 import { isObjectStrict } from '@phun-ky/typeof';
 import merge from 'lodash.merge';
 import { loadConfig as loadC12 } from 'c12';
@@ -9,6 +9,13 @@ import { get, getSystemInfo, readJSON } from './util.js';
 
 const debug = util.debug('release-it:config');
 const defaultConfig = readJSON(new URL('../config/release-it.json', import.meta.url));
+
+const defu = createDefu((obj, key, value) => {
+  if (Array.isArray(obj[key]) && Array.isArray(value)) {
+    obj[key] = value;
+    return true;
+  }
+});
 
 class Config {
   constructor(config = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,12 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",
-        "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
         "@phun-ky/typeof": "2.0.3",
         "async-retry": "1.3.3",
         "c12": "3.3.3",
         "ci-info": "^4.4.0",
+        "defu": "^6.0.0",
         "eta": "4.5.1",
         "git-url-parse": "16.1.0",
         "issue-parser": "7.0.1",
@@ -735,15 +735,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nodeutils/defaults-deep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
-      "integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.15.0"
-      }
-    },
     "node_modules/@npmcli/config": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-8.3.4.tgz",
@@ -1209,9 +1200,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1229,9 +1217,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1249,9 +1234,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1269,9 +1251,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,9 +1268,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1309,9 +1285,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,9 +1302,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1319,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1579,9 +1546,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1596,9 +1560,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1613,9 +1574,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,9 +1588,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1647,9 +1602,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1664,9 +1616,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,9 +1630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,9 +1644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4272,12 +4215,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "license": "MIT",
   "dependencies": {
     "@inquirer/prompts": "8.3.2",
-    "@nodeutils/defaults-deep": "1.1.0",
+    "defu": "^6.0.0",
     "@octokit/rest": "22.0.1",
     "@phun-ky/typeof": "2.0.3",
     "async-retry": "1.3.3",

--- a/test/config.js
+++ b/test/config.js
@@ -65,6 +65,19 @@ describe('config', async () => {
     assert.equal(config.options.npm.publish, false);
   });
 
+  test('should replace (not concatenate) array options with user-provided arrays', async () => {
+    const config = new Config({ git: { pushArgs: ['--force'] }, npm: { publishArgs: ['--tag=next'] } });
+    await config.init();
+    assert.deepEqual(config.options.git.pushArgs, ['--force']);
+    assert.deepEqual(config.options.npm.publishArgs, ['--tag=next']);
+  });
+
+  test('should allow empty array to clear default array option', async () => {
+    const config = new Config({ git: { pushArgs: [] } });
+    await config.init();
+    assert.deepEqual(config.options.git.pushArgs, []);
+  });
+
   test('should read YAML config', async () => {
     const config = new Config({ configDir: './test/stub/config/yaml' });
     await config.init();


### PR DESCRIPTION
Resolves #1294 

## Summary
- Replace usage of `@nodeutils/defaults-deep` with `defu` and update dependency.
- Files changed: `lib/config.js`, `package.json`. Run `npm install` to update `package-lock.json`.

## Motivation
- `@nodeutils/defaults-deep` pins `lodash@^4.17.4` and resolves to `lodash@4.17.23` That version of lodash is flagged by Trivy for **CVE-2026-4800** (HIGH — arbitrary code execution via untrusted input in template imports). Fix is available in `lodash@4.18.0`. 
- `@nodeutils/defaults-deep` is not maintained, last commit is in back 2018.

## What I changed
- `lib/config.js`: replaced import and call to use `defu`.
- `package.json`: removed `@nodeutils/defaults-deep` and added `defu`.
- `package-lock.json`: generated by `npm install`

## Tests
- Existing tests in `test/config.js` cover merge/default behavior (examples: “should merge provided options”, “should contain default values”, nested `npm.publish` override).
- Run locally:
```bash
npm install
npm test
```

## Notes for reviewers
- Behavior is intended to be identical; `defu` mutates its first argument — an empty object is used to avoid mutating inputs.