### PR TITLE
fix: add 'Accept-Encoding' header to GitLab API requests

### DIFF
--- a/lib/plugin/gitlab/GitLab.js
+++ b/lib/plugin/gitlab/GitLab.js
@@ -171,6 +171,7 @@ class GitLab extends Release {
     const url = `${baseUrl}/${endpoint}${options.searchParams ? `?${new URLSearchParams(options.searchParams)}` : ''}`;
     const headers = {
       'user-agent': 'webpro/release-it',
+      'Accept-Encoding': 'identity',
       [tokenHeader]: this.token
     };
     // When using fetch() with FormData bodies, we should not set the Content-Type header.


### PR DESCRIPTION
## Problem

  When communicating with the GitLab API, Node.js's built-in `fetch` (powered by
  undici) can negotiate gzip-compressed responses. In certain timing conditions the
  response body arrives as raw compressed bytes that are passed directly to
  `JSON.parse`, which then fails with:

  SyntaxError: Unexpected token '', "▒   n▒▒"... is not valid JSON
      at JSON.parse ()
      at parseJSONFromBytes (node:internal/deps/undici/undici:4280:19)
      at successSteps (node:internal/deps/undici/undici:6884:27)
      at readAllBytes (node:internal/deps/undici/undici:5742:13)

  This surfaces as a misleading authentication error:

  ERROR Could not authenticate with GitLab using environment variable "AUTH_TOKEN".

  even though the token itself is perfectly valid.

  ## Root cause

  undici sends `Accept-Encoding: gzip, deflate, br` by default. GitLab honours
  this and compresses the response body. However, undici's automatic decompression
  is not always triggered when the response is consumed via `.json()` / manual
  `JSON.parse`, so the raw binary payload reaches the parser.

  ## Fix

  Set `Accept-Encoding: identity` on every GitLab API request to opt out of
  content encoding. This forces GitLab to return plain-text JSON, which is safe to
  parse without any decompression step.

  ```diff
   const headers = {
     'user-agent': 'webpro/release-it',
  +  'Accept-Encoding': 'identity',
     [tokenHeader]: this.token
   };
 ```

## Testing
  
  Reproduce by running release-it against a GitLab instance (or CI pipeline) that
  returns compressed responses and verifying that authentication and release
  creation succeed without the SyntaxError.
