### PR TITLE
fix: ensure release body is an empty string instead of null

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -218,16 +218,14 @@ class GitHub extends Release {
       discussionCategoryName = undefined
     } = this.options;
     const { tagName } = this.config.getContext();
-    const { version, releaseNotes, isUpdate } = this.getContext();
+    const { version, releaseNotes } = this.getContext();
     const { isPreRelease } = parseVersion(version);
     const name = format(releaseName, this.config.getContext());
     const releaseNotesObject = this.options.releaseNotes;
 
-    const body = autoGenerate
-      ? isUpdate
-        ? null
-        : ''
-      : truncateBody(releaseNotesObject?.commit ? await this.renderReleaseNotes(releaseNotesObject) : releaseNotes);
+    const resolvedReleaseNotes =
+      (releaseNotesObject?.commit ? await this.renderReleaseNotes(releaseNotesObject) : releaseNotes) ?? '';
+    const body = !autoGenerate ? truncateBody(resolvedReleaseNotes) : '';
 
     /**
      * @type {CreateReleaseOptions}

--- a/test/github.js
+++ b/test/github.js
@@ -615,7 +615,7 @@ describe('github', () => {
         tag_name: '2.0.2',
         name: 'Release 2.0.2',
         generate_release_notes: false,
-        body: null,
+        body: '',
         discussion_category_name: 'Announcement'
       }
     });

--- a/test/stub/github.js
+++ b/test/stub/github.js
@@ -38,7 +38,7 @@ export const interceptCreate = (
     body: {
       tag_name,
       name = '',
-      body = null,
+      body = '',
       prerelease = false,
       draft = false,
       generate_release_notes = false,
@@ -81,7 +81,7 @@ export const interceptUpdate = (
     body: {
       tag_name,
       name = '',
-      body = null,
+      body = '',
       prerelease = false,
       draft = false,
       generate_release_notes = false,


### PR DESCRIPTION
Error: 
```
ERROR 422 (Invalid request.

For 'properties/body', nil is not a string. 
```

Reproduce:
Create release with custom changelog, but with a empty changelog.