### PR TITLE
fix: dirty tree detection

### DIFF
--- a/lib/plugin/git/Git.js
+++ b/lib/plugin/git/Git.js
@@ -124,10 +124,12 @@ class Git extends GitBase {
   }
 
   isWorkingDirClean() {
-    return this.exec('git diff --quiet HEAD', { options }).then(
-      () => true,
-      () => false
-    );
+    return this.exec('git update-index -q --refresh', { options })
+      .then(() => this.exec('git diff-index --quiet HEAD --', { options }))
+      .then(
+        () => true,
+        () => false
+      );
   }
 
   async getUpstreamArgs(pushRepo) {

--- a/test/git.js
+++ b/test/git.js
@@ -313,8 +313,8 @@ describe('git', () => {
     await gitClient.tag();
     await gitClient.rollbackOnce();
 
-    assert.equal(exec.mock.calls[11].arguments[0], 'git tag --delete v1.2.4');
-    assert.equal(exec.mock.calls[12].arguments[0], 'git reset --hard HEAD~1');
+    assert.equal(exec.mock.calls[12].arguments[0], 'git tag --delete v1.2.4');
+    assert.equal(exec.mock.calls[13].arguments[0], 'git reset --hard HEAD~1');
   });
 
   // To get this test to pass, I had to switch between spawnsync and execsync somehow
@@ -345,7 +345,7 @@ describe('git', () => {
     } catch (e) {
       // push would fail with an error since HEAD is behind origin
     }
-    assert.equal(exec.mock.calls[15].arguments[0], 'git push origin --delete v1.2.4');
+    assert.equal(exec.mock.calls[16].arguments[0], 'git push origin --delete v1.2.4');
   });
 
   test('should skip rollback when push fails but package is already published', async t => {


### PR DESCRIPTION
Ref: #687, #1300

Replaces `git diff --quiet HEAD` with `git update-index -q --refresh` followed by `git diff-index --quiet HEAD --`.

This should fix intermittent issues with dirty tree detection.

While this is difficult to test reliably, `git diff` refreshes the index internally but can return early before the index is fully and synchronously updated. Running `git update-index -q --refresh` is the safest way to ensure the index is fully updated before making a comparison. Additionally, `git diff` is a porcelain command designed for human use; switching to the plumbing command `git diff-index --quiet HEAD --` provides a more stable and reliable check for automation.

**Performance Note:**
Tested using `hyperfine`, the execution speeds of the two diff commands themselves are practically identical. Explicitly running `update-index` does double the execution time (from ~67ms to ~120ms on my system), but the absolute overhead is negligible and well worth the guarantee of a reliable dirty check.