### PR TITLE
feat: add requireVersionFail option to exit 0 when no new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Alternatively, a plugin can be used to override this (e.g. to manage a `VERSION`
 
 Add the `--release-version` flag to print the **next** version without releasing anything.
 
+By default, `--release-version` exits with code `1` when no new version can be determined. Set
+`requireVersionFail: false` or pass `--no-requireVersionFail` to exit with code `0` without a warning instead.
+
 ## Git
 
 Git projects are supported well by release-it, automating the tasks to stage, commit, tag and push releases to any Git

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -1,5 +1,6 @@
 {
   "quiet": false,
+  "requireVersionFail": true,
   "hooks": {},
   "git": {
     "changelog": "git log --pretty=format:\"* %s (%h)\" ${from}...${to}",

--- a/docs/dry-runs.md
+++ b/docs/dry-runs.md
@@ -18,4 +18,7 @@ $ git rev-parse --git-dir
 
 To print the next version without releasing anything, use the `--release-version` flag.
 
+By default, this exits with code `1` when no new version can be determined. Set `requireVersionFail: false` or pass
+`--no-requireVersionFail` to exit with code `0` without a warning instead.
+
 To print the changelog without releasing anything, use the `--changelog` flag.

--- a/lib/args.js
+++ b/lib/args.js
@@ -13,6 +13,7 @@ const booleanOptions = [
   'dry-run',
   'ci',
   'quiet',
+  'requireVersionFail',
   'git',
   'npm',
   'github',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,8 @@ const helpText = `Release It! v${pkg.version}
      --release-version   Print version number to be released
      --changelog         Print changelog for the version to be released
      --quiet             Suppress preview output during release
+     --no-requireVersionFail
+                         Exit with code 0 if --release-version finds no version
   -V --verbose           Verbose output (user hooks output)
   -VV                    Extra verbose output (also internal commands output)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,8 +107,12 @@ const runTasks = async (opts, di) => {
         console.log(version);
         process.exit(0);
       } else {
-        log.warn(`No new version to release`);
-        process.exit(1);
+        if (options.requireVersionFail) {
+          log.warn(`No new version to release`);
+          process.exit(1);
+        } else {
+          process.exit(0);
+        }
       }
     }
 

--- a/schema/release-it.json
+++ b/schema/release-it.json
@@ -93,6 +93,11 @@
       "type": "boolean",
       "default": false,
       "description": "Suppress preview output (changelog, changeset, release notes) during the release flow. Does not affect the --changelog mode."
+    },
+    "requireVersionFail": {
+      "type": "boolean",
+      "default": true,
+      "description": "Exit with code 1 and show a warning when --release-version cannot determine a new version."
     }
   }
 }

--- a/test/args.js
+++ b/test/args.js
@@ -8,6 +8,7 @@ test('should parse boolean arguments', () => {
     '--ci',
     '--github=false',
     '--no-npm',
+    '--no-requireVersionFail',
     '--git.addUntrackedFiles=true',
     '--git.commit=false',
     '--no-git.tag',
@@ -20,6 +21,7 @@ test('should parse boolean arguments', () => {
   assert.equal(result.ci, true);
   assert.equal(result.github, false);
   assert.equal(result.npm, false);
+  assert.equal(result.requireVersionFail, false);
   assert.equal(result.git.addUntrackedFiles, true);
   assert.equal(result.git.commit, false);
   assert.equal(result.git.tag, false);

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -51,6 +51,13 @@ describe('tasks', () => {
     return { log, spinner, config, shell };
   };
 
+  const mockExit = t =>
+    t.mock.method(process, 'exit', code => {
+      const err = new Error(`process.exit: ${code}`);
+      err.code = code;
+      throw err;
+    });
+
   before(() => {
     mocker.mockGlobal();
   });
@@ -116,6 +123,36 @@ describe('tasks', () => {
     assert.match(log.log.mock.calls.at(-1).arguments[0], /Done \(in [0-9]+s\.\)/);
     const stdout = childProcess.execSync('git describe --tags --match=* --abbrev=0', { encoding: 'utf-8' });
     assert.equal(stdout.trim(), '1.2.4');
+  });
+
+  test('should fail release-version when no new version is available by default', async t => {
+    const exit = mockExit(t);
+
+    await assert.rejects(runTasks({}, getContainer({ 'release-version': true, increment: 'foo' })), err => {
+      assert.equal(err.code, 1);
+      return true;
+    });
+
+    assert.equal(exit.mock.callCount(), 1);
+    assert.equal(exit.mock.calls[0].arguments[0], 1);
+    assert.equal(log.warn.mock.callCount(), 1);
+    assert.equal(log.warn.mock.calls[0].arguments[0], 'No new version to release');
+  });
+
+  test('should pass release-version when no new version is available and requireVersionFail is false', async t => {
+    const exit = mockExit(t);
+
+    await assert.rejects(
+      runTasks({}, getContainer({ 'release-version': true, increment: 'foo', requireVersionFail: false })),
+      err => {
+        assert.equal(err.code, 0);
+        return true;
+      }
+    );
+
+    assert.equal(exit.mock.callCount(), 1);
+    assert.equal(exit.mock.calls[0].arguments[0], 0);
+    assert.equal(log.warn.mock.callCount(), 0);
   });
 
   test('should use pkg.version', async () => {

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -211,4 +211,7 @@ export interface Config {
 
   /** @default false */
   quiet?: boolean;
+
+  /** @default true */
+  requireVersionFail?: boolean;
 }


### PR DESCRIPTION
Fixes #1277

## Problem
When release-it determines there is no new version to release (for example under conventional-commits with `bumpStrict`), it logs a warning and exits 1, which fails CI pipelines that legitimately have nothing to release.

## Fix
Add a top-level `requireVersionFail` option (default `true`, preserving current behavior). When set to `false` (via `--no-requireVersionFail`), release-it exits 0 in that case instead of 1. The name mirrors the existing `git.requireCommitsFail` convention, and the option is threaded through args, CLI help, schema, types, defaults, and docs.

## Tests
Added a regression test asserting exit 0 when `requireVersionFail` is false and no new version is available, plus a guard that the default still exits 1.
