### PR TITLE
Validate missing config argument

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -1,4 +1,4 @@
-import parseArgs from 'yargs-parser';
+import { parseArgs } from 'node:util';
 
 const aliases = {
   c: 'config',
@@ -47,18 +47,103 @@ const booleanOptions = [
   'npm.skipChecks'
 ];
 
-export const parseCliArguments = args => {
-  const options = parseArgs(args, {
-    boolean: booleanOptions,
-    alias: aliases,
-    configuration: {
-      'parse-numbers': false,
-      'camel-case-expansion': false
+const configOptions = new Set(['--config', '-c']);
+const booleanOptionSet = new Set([...booleanOptions, 'help', 'version', 'verbose']);
+
+const parseOptions = Object.fromEntries(booleanOptions.map(option => [option, { type: 'boolean' }]));
+
+Object.assign(parseOptions, {
+  config: { type: 'string', short: 'c' },
+  'dry-run': { type: 'boolean', short: 'd' },
+  help: { type: 'boolean', short: 'h' },
+  increment: { type: 'string', short: 'i' },
+  version: { type: 'boolean', short: 'v' },
+  verbose: { type: 'boolean', short: 'V', multiple: true }
+});
+
+const validateConfigOption = args => {
+  const index = args.findIndex(arg => configOptions.has(arg));
+  const value = args[index + 1];
+
+  if (index !== -1 && (!value || value.startsWith('-'))) {
+    throw new Error('Invalid argument: "--config" must be immediately followed by the configuration file name.');
+  }
+};
+
+const setDottedOption = (options, key, value) => {
+  const parts = key.split('.');
+  const name = parts.pop();
+  const target = parts.reduce((options, part) => {
+    if (options[part] === undefined) options[part] = {};
+    return options[part];
+  }, options);
+
+  target[name] = value;
+};
+
+const setAliasOptions = options => {
+  for (const [short, name] of Object.entries(aliases)) {
+    if (options[name] !== undefined) options[short] = options[name];
+  }
+};
+
+const normalizeBooleanValue = (key, value) => {
+  if (!booleanOptionSet.has(key)) return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+};
+
+const normalizeOptions = ({ values, tokens }) => {
+  const consumedPositionals = new Set();
+  const normalizedValues = Object.fromEntries(Object.entries(values));
+
+  for (const [index, token] of tokens.entries()) {
+    const nextToken = tokens[index + 1];
+
+    if (
+      token.kind === 'option' &&
+      !booleanOptionSet.has(token.name) &&
+      normalizedValues[token.name] === true &&
+      nextToken?.kind === 'positional' &&
+      nextToken.index === token.index + 1
+    ) {
+      normalizedValues[token.name] = nextToken.value;
+      consumedPositionals.add(nextToken.index);
     }
-  });
-  if (options.V) {
-    options.verbose = typeof options.V === 'boolean' ? options.V : options.V.length;
-    delete options.V;
+  }
+
+  const options = {
+    _: tokens
+      .filter(token => token.kind === 'positional' && !consumedPositionals.has(token.index))
+      .map(token => token.value)
+  };
+
+  for (const [key, value] of Object.entries(normalizedValues)) {
+    setDottedOption(options, key, normalizeBooleanValue(key, value));
+  }
+
+  setAliasOptions(options);
+
+  return options;
+};
+
+export const parseCliArguments = args => {
+  validateConfigOption(args);
+
+  const options = normalizeOptions(
+    parseArgs({
+      args,
+      allowNegative: true,
+      allowPositionals: true,
+      options: parseOptions,
+      strict: false,
+      tokens: true
+    })
+  );
+
+  if (Array.isArray(options.verbose)) {
+    options.verbose = options.verbose.length;
   }
   options.increment = options._[0] || options.i;
   return options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,7 @@
         "tinyglobby": "0.2.15",
         "undici": "7.24.5",
         "url-join": "5.0.0",
-        "wildcard-match": "5.1.4",
-        "yargs-parser": "22.0.0"
+        "wildcard-match": "5.1.4"
       },
       "bin": {
         "release-it": "bin/release-it.js"
@@ -7448,15 +7447,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -99,8 +99,7 @@
     "tinyglobby": "0.2.15",
     "undici": "7.24.5",
     "url-join": "5.0.0",
-    "wildcard-match": "5.1.4",
-    "yargs-parser": "22.0.0"
+    "wildcard-match": "5.1.4"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/test/args.js
+++ b/test/args.js
@@ -25,3 +25,30 @@ test('should parse boolean arguments', () => {
   assert.equal(result.git.tag, false);
   assert.equal(result.git.commitMessage, 'test');
 });
+
+test('should parse argument aliases and positionals', () => {
+  const result = parseCliArguments(['minor', '-c', '.release-it.json', '-VVV', '--git.pushRepo', 'origin']);
+
+  assert.equal(result.increment, 'minor');
+  assert.equal(result.config, '.release-it.json');
+  assert.equal(result.c, '.release-it.json');
+  assert.equal(result.verbose, 3);
+  assert.equal(result.git.pushRepo, 'origin');
+});
+
+test('should throw a helpful error when --config is not followed by a file name', () => {
+  const args = [
+    '--ci',
+    '--no-git.commit',
+    '--no-npm.publish',
+    '--config',
+    '--git.pushRepo=gitlab',
+    '.release-it.ts',
+    '--pre-release'
+  ];
+
+  assert.throws(
+    () => parseCliArguments(args),
+    new Error('Invalid argument: "--config" must be immediately followed by the configuration file name.')
+  );
+});


### PR DESCRIPTION
Fixes #1196.

This adds a CLI argument validation step for `--config`/`-c` so release-it reports a clear error when the config option is followed by another flag instead of a configuration file name.

Validation run:
- `node --env-file=.env.test --test test/args.js`
- `npm run lint`

I also tried `npm test`, but the existing extended configuration fetch tests failed locally with `Invalid configuration file at .release-it`, and the full run later stalled in unrelated integration tests.