### PR TITLE
Fix npm publish workspace config resolution

### DIFF
--- a/lib/plugin/npm/npm.js
+++ b/lib/plugin/npm/npm.js
@@ -277,16 +277,9 @@ class npm extends Plugin {
       this.log.warn('Skip publish: package is private.');
       return false;
     }
-    const args = [
-      publishPath,
-      '--tag',
-      tag,
-      publishPackageManager === 'npm' && '--workspaces=false',
-      ...otpArgs,
-      dryRunArg,
-      registryArg,
-      ...fixArgs(publishArgs)
-    ].filter(Boolean);
+    const args = [publishPath, '--tag', tag, ...otpArgs, dryRunArg, registryArg, ...fixArgs(publishArgs)].filter(
+      Boolean
+    );
     const publishCommand = stage ? ['stage', 'publish'] : ['publish'];
     const isInteractive = !stage && (!this.config.isCI || Boolean(this.config.isPromptOnlyVersion));
     return this.exec([publishPackageManager, ...publishCommand, ...args], {
@@ -299,7 +292,9 @@ class npm extends Plugin {
           } else {
             const id = output?.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)?.[0];
             const approve = `${publishPackageManager} stage approve${id ? ` ${id}` : ''}`;
-            this.log.log(`📦 Staged, not yet published. Approve at ${this.getStagedPackagesUrl()} (or \`${approve}\`).`);
+            this.log.log(
+              `📦 Staged, not yet published. Approve at ${this.getStagedPackagesUrl()} (or \`${approve}\`).`
+            );
           }
         } else {
           this.setContext({ isReleased: true });

--- a/test/npm.js
+++ b/test/npm.js
@@ -165,14 +165,7 @@ describe('npm', async () => {
     exec.mock.mockImplementationOnce(() => Promise.reject(new Error(whoamiError)), 1);
     exec.mock.mockImplementationOnce(() => Promise.reject(new Error(accessError)), 2);
     await runTasks(npmClient);
-    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], [
-      'npm',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false'
-    ]);
+    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], ['npm', 'publish', '.', '--tag', 'latest']);
   });
 
   test('should not throw if npm returns 400 for unsupported ping/whoami/access', async t => {
@@ -185,14 +178,7 @@ describe('npm', async () => {
     exec.mock.mockImplementationOnce(() => Promise.reject(new Error(whoamiError)), 1);
     exec.mock.mockImplementationOnce(() => Promise.reject(new Error(accessError)), 2);
     await runTasks(npmClient);
-    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], [
-      'npm',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false'
-    ]);
+    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], ['npm', 'publish', '.', '--tag', 'latest']);
   });
 
   test('should throw if user is not authenticated', async t => {
@@ -262,27 +248,9 @@ describe('npm', async () => {
     });
 
     assert.equal(exec.mock.callCount(), 3);
-    assert.deepEqual(exec.mock.calls[0].arguments[0], ['npm', 'publish', '.', '--tag', 'latest', '--workspaces=false']);
-    assert.deepEqual(exec.mock.calls[1].arguments[0], [
-      'npm',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false',
-      '--otp',
-      '123'
-    ]);
-    assert.deepEqual(exec.mock.calls[2].arguments[0], [
-      'npm',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false',
-      '--otp',
-      '123456'
-    ]);
+    assert.deepEqual(exec.mock.calls[0].arguments[0], ['npm', 'publish', '.', '--tag', 'latest']);
+    assert.deepEqual(exec.mock.calls[1].arguments[0], ['npm', 'publish', '.', '--tag', 'latest', '--otp', '123']);
+    assert.deepEqual(exec.mock.calls[2].arguments[0], ['npm', 'publish', '.', '--tag', 'latest', '--otp', '123456']);
 
     assert.equal(npmClient.log.warn.mock.callCount(), 1);
     assert.equal(npmClient.log.warn.mock.calls[0].arguments[0], 'The provided OTP is incorrect or has expired.');
@@ -302,7 +270,7 @@ describe('npm', async () => {
     assert.equal(exec2.mock.calls.at(-1).arguments[1].interactive, false);
   });
 
-  test('should publish', async t => {
+  test('should publish without forcing workspaces off', async t => {
     const npmClient = await factory(npm);
     const exec = t.mock.method(npmClient.shell, 'exec', command => {
       if (command === 'npm whoami') return Promise.resolve('john');
@@ -311,14 +279,7 @@ describe('npm', async () => {
       return Promise.resolve();
     });
     await runTasks(npmClient);
-    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], [
-      'npm',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false'
-    ]);
+    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], ['npm', 'publish', '.', '--tag', 'latest']);
   });
 
   test('should use extra publish arguments', async t => {
@@ -332,7 +293,6 @@ describe('npm', async () => {
       '.',
       '--tag',
       'latest',
-      '--workspaces=false',
       '--registry=http://my-internal-registry.local'
     ]);
   });
@@ -342,15 +302,7 @@ describe('npm', async () => {
     const npmClient = await factory(npm, { options });
     const exec = t.mock.method(npmClient.shell, 'exec', () => Promise.resolve());
     await runTasks(npmClient);
-    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], [
-      'npm',
-      'stage',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false'
-    ]);
+    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], ['npm', 'stage', 'publish', '.', '--tag', 'latest']);
   });
 
   test('should not pass --otp when staging (2FA happens at approval)', async t => {
@@ -358,15 +310,7 @@ describe('npm', async () => {
     npmClient.setContext({ name: 'pkg' });
     const exec = t.mock.method(npmClient.shell, 'exec', () => Promise.resolve());
     await npmClient.publish({ otp: '123456' });
-    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], [
-      'npm',
-      'stage',
-      'publish',
-      '.',
-      '--tag',
-      'latest',
-      '--workspaces=false'
-    ]);
+    assert.deepEqual(exec.mock.calls.at(-1).arguments[0], ['npm', 'stage', 'publish', '.', '--tag', 'latest']);
   });
 
   test('should stage publish with pnpm', async t => {
@@ -388,7 +332,10 @@ describe('npm', async () => {
     scoped.setContext({ name: '@release-it/x', username: 'webpro' });
     t.mock.method(scoped.shell, 'exec', () => Promise.resolve());
     await scoped.publish();
-    assert.match(scoped.log.log.mock.calls.map(c => c.arguments[0]).join('\n'), /settings\/release-it\/staged-packages/);
+    assert.match(
+      scoped.log.log.mock.calls.map(c => c.arguments[0]).join('\n'),
+      /settings\/release-it\/staged-packages/
+    );
   });
 
   test('should surface the stage id from publish output in the approval message', async t => {
@@ -456,7 +403,7 @@ describe('npm', async () => {
       'npm show @my-scope/my-pkg@latest version --registry https://gitlab.com/api/v4/projects/my-scope%2Fmy-pkg/packages/npm/',
       'npm --version',
       'npm version 1.0.1 --no-git-tag-version --workspaces=false',
-      'npm publish . --tag latest --workspaces=false --registry https://gitlab.com/api/v4/projects/my-scope%2Fmy-pkg/packages/npm/'
+      'npm publish . --tag latest --registry https://gitlab.com/api/v4/projects/my-scope%2Fmy-pkg/packages/npm/'
     ]);
   });
 

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -189,7 +189,7 @@ describe('tasks', () => {
       'npm --version',
       `npm access ${npmMajorVersion >= 9 ? 'list collaborators --json' : 'ls-collaborators'} ${pkgName}`,
       'npm version 1.0.1 --no-git-tag-version --workspaces=false',
-      'npm publish . --tag latest --workspaces=false'
+      'npm publish . --tag latest'
     ]);
 
     assert(log.obtrusive.mock.calls[0].arguments[0].endsWith(`release ${pkgName} (1.0.0...1.0.1)`));
@@ -324,7 +324,7 @@ describe('tasks', () => {
       'npm --version',
       `npm access ${npmMajorVersion >= 9 ? 'list collaborators --json' : 'ls-collaborators'} ${pkgName}`,
       'npm version 1.1.0-alpha.0 --no-git-tag-version --workspaces=false',
-      'npm publish . --tag alpha --workspaces=false'
+      'npm publish . --tag alpha'
     ]);
 
     const commitMessage = childProcess.execSync('git log --oneline --format=%B -n 1 HEAD', {
@@ -365,7 +365,7 @@ describe('tasks', () => {
       'npm --version',
       `npm access ${npmMajorVersion >= 9 ? 'list collaborators --json' : 'ls-collaborators'} ${pkgName}`,
       'npm version 2.0.0-0 --no-git-tag-version --workspaces=false',
-      'npm publish . --tag next --workspaces=false'
+      'npm publish . --tag next'
     ]);
 
     const stdout = childProcess.execSync('git describe --tags --match=* --abbrev=0', { encoding: 'utf-8' });
@@ -407,7 +407,7 @@ describe('tasks', () => {
     await runTasks({}, container);
 
     const npmArgs = getArgs(exec, 'npm');
-    assert.equal(npmArgs[6], 'npm publish . --tag latest --workspaces=false');
+    assert.equal(npmArgs[6], 'npm publish . --tag latest');
   });
 
   test('should use pkg.publishConfig.registry', async t => {


### PR DESCRIPTION
## Summary
- Stop forcing `--workspaces=false` on `npm publish` / `npm stage publish` so npm can resolve workspace-root `.npmrc` scoped registry config.
- Keep the existing `npm version --workspaces=false` behavior unchanged.
- Update npm/task tests to cover publish commands without the forced workspace flag.

Fixes #1308

## Test plan
- `npm ci`
- `node --env-file=.env.test --test test/npm.js`
- `node --env-file=.env.test --test test/tasks.js`
- `npm run lint`
- `git diff --check`
- `npm test`
- Manual dry-run repro: `npm publish . --tag rc --dry-run` uses the workspace root scoped registry, while adding `--workspaces=false` falls back to npmjs.org.