### PR TITLE
fix(ci): do not run integration on forks

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-
+    if: ${{ github.repository_owner == 'release-it' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
#### Description

This PR adds a check to the `pkg.pr.new.yml` workflow to prevent it from running in any forks.
The reason is that in forks, the action is [failing every time](https://github.com/trueberryless/release-it-release-it/actions/workflows/pkg.pr.new.yml) because the GitHub app is not installed (and not permitted if installed I guess):

```bash
Check failed (404): {"url":"/check","statusCode":404,"statusMessage":"Not Found","message":"The app https://github.com/apps/pkg-pr-new is not installed on trueberryless/webpro-nl-knip.","stack":""}
```