### PR TITLE
Pin GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -13,8 +13,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # 1.0.17
         with:
           use-quiet-mode: 'yes'
           config-file: .github/workflows/markdown-link-check.json

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'release-it' }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - run: npx --yes pkg-pr-new publish --compact --comment=update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
     name: ${{ matrix.os }} (Node v${{ matrix.node }})
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
       - run: git config --global user.name User


### PR DESCRIPTION
Supersedes #1309.

Pin every external GitHub Action to a full commit SHA while retaining release comments for Dependabot updates.

- upgrade `actions/checkout` to 7.0.0
- pin `actions/setup-node` 6.4.0 and `github/codeql-action` 4.37.0
- replace `checkout@main` in the markdown workflow
- upgrade the stale markdown-link-check `v1` tag to release 1.0.17

Verification:

- `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- full-SHA check across every workflow `uses:` reference
- `npm run lint`
- `npm test` (278 passed, 2 skipped)
