### PR TITLE
Prevent duplicate comments on resolved issues and PRs

### DIFF
--- a/lib/plugin/github/GitHub.js
+++ b/lib/plugin/github/GitHub.js
@@ -459,7 +459,12 @@ class GitHub extends Release {
 
     const shas = getCommitsFromChangelog(changelog);
     const searchResults = await Promise.all(searchQueries(this.client, owner, repo, shas));
-    const mergedPullRequests = searchResults.flatMap(items => items.map(item => ({ type: 'pr', number: item.number })));
+    // A pull request whose commits span more than one search query is returned by each of them,
+    // so the numbers must be deduplicated to comment only once per pull request.
+    const mergedPullRequests = [...new Set(searchResults.flat().map(item => item.number))].map(number => ({
+      type: 'pr',
+      number
+    }));
 
     const hostURL = 'https://' + (this.options.host || host);
     const resolvedIssues = getResolvedIssuesFromChangelog(hostURL, owner, repo, changelog);

--- a/lib/plugin/github/util.js
+++ b/lib/plugin/github/util.js
@@ -33,10 +33,11 @@ export const getCommitsFromChangelog = changelog => {
 
 export const getResolvedIssuesFromChangelog = (host, owner, repo, changelog) => {
   const parser = issueParser('github', { hosts: [host] });
-  return changelog
+  const numbers = changelog
     .split('\n')
     .map(parser)
     .flatMap(parsed => parsed.actions.close)
     .filter(action => !action.slug || action.slug === `${owner}/${repo}`)
-    .map(action => ({ type: 'issue', number: parseInt(action.issue, 10) }));
+    .map(action => parseInt(action.issue, 10));
+  return [...new Set(numbers)].map(number => ({ type: 'issue', number }));
 };

--- a/test/github.js
+++ b/test/github.js
@@ -667,6 +667,81 @@ describe('github', () => {
     );
   });
 
+  test('should not comment on the same pull request more than once', async t => {
+    const options = {
+      // The shared `git` constant sets changelog to '', which makes getChangelog()
+      // return before ever running the log command - this test needs a real
+      // changelog to reach commentOnResolvedItems, so it restores the default template.
+      git: { changelog: 'git log --pretty=format:"* %s (%h)" ${from}...${to}' },
+      github: {
+        pushRepo,
+        tokenRef,
+        release: true,
+        releaseName: 'Release ${tagName}',
+        releaseNotes: 'echo Custom notes',
+        comments: { submit: true }
+      }
+    };
+    const github = await factory(GitHub, { options });
+
+    // Enough commits that getSearchQueries splits them into more than one search
+    // query - the situation in which a pull request whose commits span multiple
+    // queries is returned, and therefore commented on, once per query.
+    const commits = Array.from({ length: 24 }, (_, i) => String(1000000 + i));
+    const changelog = commits.map(sha => `* Some commit (${sha})`).join('\n');
+    const [firstQuery, secondQuery] = getSearchQueries('repo:user/repo+type:pr+is:merged', commits, '+');
+
+    const original = github.shell.exec.bind(github.shell);
+    t.mock.method(github.shell, 'exec', (...args) => {
+      if (args[0] === 'git log --pretty=format:"* %s (%h)" ${from}...${to}') return Promise.resolve(changelog);
+      if (args[0] === 'git describe --tags --match=* --abbrev=0') return Promise.resolve('2.0.1');
+      return original(...args);
+    });
+
+    interceptAuthentication(api);
+    interceptCollaborator(api);
+    interceptCreate(api, {
+      body: { tag_name: '2.0.2', name: 'Release 2.0.2', body: 'Custom notes', draft: false }
+    });
+
+    // Pull request #42's commits are spread across both batches, so both searches
+    // return it. The `+` separator is decoded back to a space by URLSearchParams,
+    // so the matcher has to expect that form rather than the literal query text.
+    api.get(
+      { url: '/search/issues', query: { q: firstQuery.replace(/\+/g, ' '), advanced_search: 'true' } },
+      { status: 200, body: { items: [{ number: 42 }, { number: 43 }] } }
+    );
+    api.get(
+      { url: '/search/issues', query: { q: secondQuery.replace(/\+/g, ' '), advanced_search: 'true' } },
+      { status: 200, body: { items: [{ number: 42 }] } }
+    );
+
+    // Each mentoss route is consumed on its first match, so a route only meant
+    // to be hit once cannot observe a second, buggy request - it would just
+    // silently fail to match instead of proving the duplicate happened. Register
+    // more copies than any single pull request could plausibly need, so every
+    // real request the code makes succeeds and is counted.
+    const commented = [];
+    for (let i = 0; i < 5; i++) {
+      api.post('/repos/user/repo/issues/42/comments', () => {
+        commented.push(42);
+        return { status: 201, body: {} };
+      });
+      api.post('/repos/user/repo/issues/43/comments', () => {
+        commented.push(43);
+        return { status: 201, body: {} };
+      });
+    }
+
+    await runTasks(github);
+
+    assert.deepEqual(
+      commented.sort(),
+      [42, 43],
+      'each pull request should be commented on exactly once, however many search queries returned it'
+    );
+  });
+
   test('should ignore resolved issue references in HTML comments', () => {
     const issues = getResolvedIssuesFromChangelog(
       'github.com',
@@ -675,6 +750,19 @@ describe('github', () => {
       'fixes #1 <!-- fixes #2 -->'
     );
     assert.deepEqual(issues, [{ type: 'issue', number: 1 }]);
+  });
+
+  test('should resolve an issue referenced by multiple changelog entries only once', () => {
+    const issues = getResolvedIssuesFromChangelog(
+      'github.com',
+      'release-it',
+      'release-it',
+      '* fix crash, fixes #1 (abc1234)\n* more fixes, fixes #1, closes #2 (def5678)'
+    );
+    assert.deepEqual(issues, [
+      { type: 'issue', number: 1 },
+      { type: 'issue', number: 2 }
+    ]);
   });
 
   test('should create auto-generated discussion', async t => {


### PR DESCRIPTION
## Problem

When `github.comments.submit` is enabled, the same item can receive the release comment multiple times:

- **Pull requests** — commit SHAs from the changelog are batched into multiple search queries (GitHub's search API caps queries at 256 encoded characters). A pull request whose commits span more than one batch is returned by each query, and each occurrence was commented on.
- **Issues** — an issue referenced by multiple changelog entries (e.g. two commits both saying `fixes #1`) was parsed once per reference, and commented on once per reference.

So a release with enough commits could leave multiple identical " This issue has been resolved in ..." comments on the same PR or issue.

<img width="1795" height="1824" alt="CleanShot 2026-08-05 at 16 40 57@2x" src="https://github.com/user-attachments/assets/b12b9de6-8033-417f-a150-20c1becec022" />

## Fix

Deduplicate both lists at the source:

- `commentOnResolvedItems` – merged pull request numbers from all search results go through a `Set` before being commented on
- `getResolvedIssuesFromChangelog` – resolved issue numbers are deduplicated the same way

## Tests

- Added a new test: a changelog with enough commits to produce two search queries, where both queries return PR `#42`, the test checks if only one comment has been added.
- New test case for `getResolvedIssuesFromChangelog` with the same issue number referenced on two changelog lines, but should get a comment only once
