### PR TITLE
fix: strip control characters from changelog before display

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ import Config from './config.js';
 import Shell from './shell.js';
 import Prompt from './prompt.js';
 import Spinner from './spinner.js';
-import { reduceUntil, parseVersion, castArray } from './util.js';
+import { reduceUntil, parseVersion, castArray, sanitizeForDisplay } from './util.js';
 
 const runTasks = async (opts, di) => {
   let container = {};
@@ -60,7 +60,7 @@ const runTasks = async (opts, di) => {
 
     const name = await reduceUntil(plugins, plugin => plugin.getName());
     const latestVersion = (await reduceUntil(plugins, plugin => plugin.getLatestVersion())) || '0.0.0';
-    const changelog = await reduceUntil(plugins, plugin => plugin.getChangelog(latestVersion));
+    const changelog = sanitizeForDisplay(await reduceUntil(plugins, plugin => plugin.getChangelog(latestVersion)));
 
     if (isChangelog) {
       if (changelog) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -173,6 +173,17 @@ export const getNpmEnv = () => {
   return env;
 };
 
+// Strip control characters (e.g. terminal escape sequences) from text
+// that originates from user-controlled sources such as git commit
+// messages, which have no character restrictions, before it is written
+// to the terminal. Newline is preserved since changelogs legitimately
+// span multiple lines.
+export const sanitizeForDisplay = string =>
+  string &&
+  Array.from(string)
+    .filter(char => char === '\n' || char.codePointAt(0) > 31 && char.codePointAt(0) !== 127)
+    .join('');
+
 export const upperFirst = string => {
   return string ? string.charAt(0).toUpperCase() + string.slice(1) : '';
 };


### PR DESCRIPTION
Fixes #1326

The changelog, generated from `git log` commit subjects, is shown by default on every run as part of the interactive release preview, and via `--changelog`, with no filtering of control characters. Unlike a package name or a git ref, a commit message has no character restrictions, so a crafted commit message could inject terminal escape sequences into release-it's own output during a routine release.

## Change

Adds `sanitizeForDisplay` (`lib/util.js`), which filters out characters with a code point below 32 or equal to 127, other than newline (preserved since a changelog legitimately spans multiple lines). Applied once, where the changelog value is obtained from the plugin chain in `lib/index.js`, so it covers both the `--changelog` output and the default interactive preview.

## Testing

- Reproduced the issue with a commit whose message contained a raw OSC title-set escape sequence, confirmed via a `tmux pipe-pane` capture (hex-dumped, not just visually inspected) that the raw escape bytes reached the terminal embedded in the commit subject text.
- Re-ran the same reproduction against this fix; the injected control bytes are gone, only harmless printable text remains.
- Ran the relevant parts of the test suite (`test/tasks.js`, `test/log.js`, `test/utils.js`, `test/util/*.js`, 52 tests total): all pass, including the tests specifically asserting the default changelog preview still renders correctly.
- Note on environment: the available Node here was v18.19.1, below the `engines.node: "^22.21.0 || >=24.0.0"` requirement, which caused a hard `EBADENGINE` install failure; used a Node v24.4.1 binary for installing dependencies and running tests, no project files depend on this.
